### PR TITLE
Document the contributor setup, tested from a clean clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,16 @@ Here is a template for new release sections:
 - CODE_OF_CONDUCT.md [#3](https://github.com/OpenEnergyPlatform/oekg/pull/3)
 - CITATION.cff [#2](https://github.com/OpenEnergyPlatform/oekg/pull/2)
 - oekg rework files [[#50](https://github.com/OpenEnergyPlatform/oekg/pull/50)]
+- Documentation site (mkdocs-material, deployed to GitHub Pages) [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]
+- `mhpkg/` for the Municipal Heat Planning KG — provisional name [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]
+- Dependency management with uv: `pyproject.toml`, `uv.lock`, `.python-version` [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]
+- Contributor setup instructions in CONTRIBUTING.md
+
+### Changed
+- Repository restructured around two knowledge graphs; OEKG files grouped by status
+  (`shapes/`, `eval/`, `legacy/`, `archive/`) under `oekg/` [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]
+- CONTRIBUTING.md now documents `production` as the only permanent branch, matching the
+  repository's actual practice
+
+### Removed
+- `requirements-docs.txt`, superseded by `pyproject.toml` and `uv.lock` [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,60 @@
 ## Prerequisites
 - [Git](https://git-scm.com/)
 - [GitHub](https://github.com/)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) — **only if you are editing the
+  documentation.** You do *not* need Python installed; uv fetches its own.
+
+## Local setup
+
+> This section is specific to this repository and is **not** part of the family CONTRIBUTING
+> template. Keep it when the template is next updated.
+
+**The only installable toolchain here is the documentation build.** That is not an oversight, it is
+the current truth of the repository: neither knowledge graph's data lives in these files, there is
+no test suite, and there is no validation pipeline yet. If you came to work on the graphs
+themselves, you need an editor — not an environment.
+
+```bash
+git clone https://github.com/OpenEnergyPlatform/oekg.git
+cd oekg
+uv sync --group docs
+uv run mkdocs serve
+```
+
+Then open **<http://127.0.0.1:8000/oekg/>** — note the `/oekg/` suffix, see the traps below.
+
+Three commands is the whole of it:
+
+| Command | What it does |
+|---|---|
+| `uv sync --group docs` | creates `.venv/` and installs the locked documentation toolchain |
+| `uv run mkdocs serve` | live-reloading local preview |
+| `uv run mkdocs build --strict` | **exactly** what CI runs — run it before you push |
+
+Verified from a clean clone on a machine whose system Python was 3.10: the first run takes about
+**7 seconds**, including downloading CPython 3.13 and all 30 packages. Afterwards it is instant.
+uv reads the committed `.python-version` and provisions the interpreter itself, so no contributor
+needs a particular Python.
+
+### Traps worth knowing before your first pull request
+
+1. **`mkdocs serve` does not serve the site at `/`.** `mkdocs.yml` sets a `site_url` with a path, so
+   the dev server mounts everything under **`/oekg/`**. `http://127.0.0.1:8000/` redirects there, but
+   a hand-typed deep link will not: the tech-stack page is `/oekg/tech-stack/`, not `/tech-stack/`.
+   OEKG pages carry the prefix **twice** — `/oekg/oekg/fields/` — because the site lives at `/oekg/`
+   and the page itself is `docs/oekg/fields.md`. Confusing, correct, and worth reading twice.
+2. **`strict: true` makes every warning a build failure**, broken `#anchors` included. A
+   documentation edit that looks fine in the browser can still fail CI, so run
+   `uv run mkdocs build --strict` before pushing rather than discovering it in a red pipeline.
+3. **The default branch is `production`** — not `main`, not `develop`. See the note under
+   *Permanent branches* below.
+4. **`mhpkg` is a provisional name.** Do not bake it into IRIs, prefixes or published URLs without
+   a rename path.
+5. **Never hand-edit `uv.lock`.** Change `pyproject.toml`, run `uv lock`, and commit both in the
+   same commit. CI installs with `--frozen`, which *fails* rather than silently re-resolving when
+   the two disagree.
+6. **Do not relax the `mkdocs~=1.6` pin to allow 2.0.** The reason is documented on the
+   [tech stack page](docs/tech-stack.md) and it is not a stylistic preference.
 
 ## Types of interaction
 This repository is following the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). <br>
@@ -43,10 +97,10 @@ Make a checklist for all needed steps if possible.
 
 ### 2. Solve the issue locally
 
-#### 2.0. Get the latest version of the `develop` branch
-Load the `develop branch`:
+#### 2.0. Get the latest version of the default branch
+Load the `production` branch:
 ```bash
-git checkout develop
+git checkout production
 ```
 
 Update with the latest version:
@@ -55,8 +109,13 @@ git pull
 ```
 
 ##### Permanent branches
-* production - includes the current stable version
-* develop - includes all current developments
+* production - the default branch, and the only permanent one
+
+> ⚠️ **This repository has one permanent branch, not two.** The family template describes a
+> `production` + `develop` pair. A `develop` branch existed here early on (last seen in PR #16)
+> and was abandoned; it does not exist today, so `git checkout develop` will fail. Feature
+> branches are branched from and merged back into **`production`** directly — that is what recent
+> pull requests actually did. `production` is also the branch the documentation deploy triggers on.
 
 #### 2.1. Create a new (local) branch
 Create a new feature branch:
@@ -146,7 +205,9 @@ git push
 
 ### 4. Submit a pull request (PR)
 Follow the GitHub guide [creating-a-pull-request](https://help.github.com/en/articles/creating-a-pull-request). <br>
-The PR should be directed: `base: develop` <- `compare: feature-1-collaboration`. <br>
+The PR should be directed: `base: production` <- `compare: feature-1-collaboration`. <br>
+Note the base is `production`, per *Permanent branches* above — merging there publishes the
+documentation site, so make sure `uv run mkdocs build --strict` passes first. <br>
 Add the line `Close #<issue-number>` in the description of your PR.
 When it is merged, it [automatically closes](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) the issue. <br>
 Assign a reviewer and get in contact.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Open Energy Family — Knowledge Graphs
 
+📖 **Documentation: <https://openenergyplatform.github.io/oekg/>**
+
 **This repository hosts two knowledge graphs.** They share a repository, not a model.
 
 | Directory | Graph | Domain | Status |
@@ -41,7 +43,14 @@ consists of one OWL draft. Neither directory's layout is imposed on the other.
 ├── CHANGELOG.md  CITATION.cff  CONTRIBUTING.md  CODE_OF_CONDUCT.md  LICENSE.txt
 ├── RELEASE_PROCEDURE.md   the family's release convention, adapted
 ├── USERS.cff              who uses these graphs
-└── .github/               issue and pull-request templates (no CI in this repository)
+│
+├── mkdocs.yml             the documentation site config
+├── pyproject.toml         dependency groups (uv; this repo is not an installable package)
+├── uv.lock                committed lockfile — CI installs exactly this
+├── .python-version        the interpreter uv fetches; committed on purpose, see .gitignore
+│
+└── .github/               issue and PR templates, plus the docs-deploy workflow
+                           (documentation is the ONLY thing with CI — no tests, no validation)
 
 # there is no shared/ — see below, its absence is deliberate
 ```
@@ -111,12 +120,12 @@ workflow) on top, then one section per knowledge graph.
 To build it locally:
 
 ```bash
-pip install -r requirements-docs.txt
-mkdocs serve
+uv sync --group docs
+uv run mkdocs serve
 ```
 
-> ℹ️ The site goes live once this documentation setup reaches `production` and GitHub Pages is
-> enabled for the `gh-pages` branch.
+Then open **<http://127.0.0.1:8000/oekg/>** — not `/`. See
+[CONTRIBUTING.md](./CONTRIBUTING.md#local-setup) for the full setup, including the traps.
 
 ## The OEKG in one paragraph
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -61,11 +61,11 @@ which uv downloads itself, so no system Python is required.
 | `uv.lock` | **committed** — the exact resolved set, so CI installs what you have locally |
 | `.python-version` | the interpreter uv fetches (3.13); `requires-python` is `>=3.11` |
 
-```bash
-uv sync --group docs        # install the documentation toolchain
-uv run mkdocs serve         # preview the site locally
-uv run mkdocs build --strict # what CI runs
-```
+The commands a contributor runs live in
+[CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oekg/blob/production/CONTRIBUTING.md#local-setup),
+deliberately in **one** place rather than copied here — two copies of setup instructions diverge
+within months. That page also lists the traps, including the fact that the dev server does not
+serve at `/`.
 
 CI uses `uv sync --group docs --frozen`, where `--frozen` **fails** if `uv.lock` is out of step
 with `pyproject.toml` rather than silently re-resolving — so the build cannot drift from the


### PR DESCRIPTION

## Summary of the discussion

Adds a Local setup section to CONTRIBUTING.md: the three uv commands, the traps, and a plain statement that only the documentation has an installable toolchain — there is no graph tooling and no validation pipeline to install.

Verified end to end on a fresh clone from origin, not written from theory: uv provisioned CPython 3.13 despite a system Python of 3.10, and a genuinely cold cache took 7s for the interpreter plus all 30 packages.

## Type of change (CHANGELOG.md)

### Added
Fixes three things the clean-clone test exposed:

- README told contributors to run `pip install -r requirements-docs.txt`, a file deleted when the repo moved to uv. The documented setup did not work.
- CONTRIBUTING told contributors to `git checkout develop` and target pull requests at `develop`. No such branch exists; it was abandoned around PR #16. Feature branches merge into `production` directly, which is what recent pull requests actually did.
- The root tree claimed "no CI in this repository", untrue since the docs deploy workflow landed, and omitted the dependency files entirely.

Also records the `/oekg/` prefix trap: site_url has a path, so the dev server mounts the site under /oekg/ and OEKG pages carry the prefix twice (/oekg/oekg/fields/). Hoists the documentation link to the top of the README, where it can actually be found, and points tech-stack.md at CONTRIBUTING.md rather than keeping a second copy of the commands.

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
