### PR TITLE
Pin MHPO by commit and vendor its term list

### DIFF
--- a/mhpkg/mhpo/README.md
+++ b/mhpkg/mhpo/README.md
@@ -1,0 +1,81 @@
+# The MHPO pin
+
+**MHPO is the T-Box.** All classes and properties for municipal heat planning live in
+[`municipal-heat-planning-ontology`](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology).
+This repository does not define domain terms — it **cites** them, and this directory is the
+record of which terms may be cited.
+
+| File | What it is |
+|---|---|
+| [`pin.txt`](pin.txt) | the MHPO commit this list was generated from |
+| [`terms.csv`](terms.csv) | **generated** — every term MHPO declares or uses |
+| [`extract_terms.py`](extract_terms.py) | regenerates `terms.csv` from the pin; stdlib only |
+
+> ⚠️ **`terms.csv` is generated. Do not edit it by hand.** Change `pin.txt`, re-run the script,
+> and commit both together.
+
+## Why a term list and not the ontology
+
+MHPO has **no releases and no tags**, and `https://purl.org/mhpo` redirects to the repository's
+GitHub page rather than to an ontology — individual term IRIs return 404. The only consumable
+artifact is `src/ontology/mhpo-edit.owl` on a branch, so any pin is a commit SHA by hand.
+
+Given that, a list beats a copy: it is what the LinkML schema actually needs (an IRI to cite and
+a label to recognise it by), it diffs one readable line per term instead of 57 KB of OWL
+functional syntax, and it requires no ODK, Docker or ROBOT — so working on this graph stays a
+`uv sync` away.
+
+## Usage
+
+```bash
+python mhpkg/mhpo/extract_terms.py           # regenerate terms.csv from the pin
+python mhpkg/mhpo/extract_terms.py --check   # fail if terms.csv drifts from the pin  (CI)
+python mhpkg/mhpo/extract_terms.py --latest  # report what changed on MHPO's develop  (report only)
+```
+
+To take an MHPO update: run `--latest` to see what moved, edit `commit:` in `pin.txt`,
+re-run without flags, and commit `pin.txt` and `terms.csv` in the same change.
+
+## The two checks, and why they are separate
+
+- **Consistency** (`--check`, on pull requests): regenerating from **the pinned commit** must
+  reproduce `terms.csv` exactly. This catches hand-edits and stale regeneration, and it can
+  **never fail because MHPO moved** — the pin is the input.
+- **Freshness** (`--latest`, on a schedule): compares the pin against MHPO's `develop` HEAD and
+  **reports**. It never fails a build. MHPO is owned by other people and has several branches in
+  flight; a pull request here should not turn red because a co-worker committed there.
+
+## Deprecated terms fail loudly
+
+`terms.csv` carries `deprecated` and `replaced_by` columns. When a cited term is deprecated
+upstream, the check **fails and names the successor** — it never rewrites automatically. A
+replacement can be narrower, broader or a split, so it is a semantic change that deserves a human.
+As of the current pin, **no MHPO term is deprecated**, so this path is untested in anger.
+
+## What the list contains, and one honest gap
+
+The list covers every term MHPO **declares or uses** — not just its own namespace — because the
+LinkML schema's `slot_uri` values point at RO and BFO relations, not at MHPO. At the current pin:
+
+| Source | Terms | |
+|---|---|---|
+| `mhpo` | 34 | all classes; MHPO mints **no relations of its own**, which is correct OBO practice |
+| `cco` | 4 | the parents MHPO subclasses under |
+| `bfo` | 3 | including `BFO_0000050/51` (part of / has part) |
+| `ro` | 3 | `RO_0000052`, `RO_0000053`, `RO_0000087` |
+| `iao` | 3 | two are annotation properties (`definition`, `alternative label`) |
+| `oeo` | 1 | `OEO_00360020` — the OEO alignment is real but currently minimal |
+
+> ℹ️ **12 external labels are `unresolved`, and that is recorded rather than guessed.** MHPO's
+> imports are not resolved in the editors' file, so labels for BFO, RO, CCO and OEO terms simply
+> are not present in it. Resolving them needs ROBOT and the ODK toolchain, which this repository
+> deliberately does not require. The IRIs — the part the schema needs — are complete.
+
+> 🔴 **MHPO cites `RO_*` relations it neither declares nor imports.** Its import products are BFO,
+> IAO, OEO and CCO; the only `ObjectProperty` declaration in the editors' file is `BFO_0000051`.
+> `RO_0000052`, `RO_0000053` and `RO_0000087` are used in axioms but dangle. They resolve at ODK
+> build time or not at all. Worth raising with MHPO's maintainers — it is their repository.
+
+## Provisional
+
+This directory's location is provisional: **MH-03** decides the `mhpkg/` layout and may move it.

--- a/mhpkg/mhpo/extract_terms.py
+++ b/mhpkg/mhpo/extract_terms.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Regenerate the vendored MHPO term list from the pinned commit.
+
+This repository does not vendor MHPO itself. It vendors a *term list* — every term MHPO
+declares or uses — because that is the whole of what the LinkML schema needs: an IRI to put
+in `class_uri` / `slot_uri`, and a label so a human can tell which term that is.
+
+Why a list and not the ontology:
+
+* MHPO has **no releases and no tags**, and `purl.org/mhpo` redirects to the repository's
+  GitHub page rather than to an ontology. The only consumable artifact is `mhpo-edit.owl` on
+  a branch, so whatever we take has to be pinned to a commit by hand.
+* A list diffs one readable line per term. A 57 KB OWL functional-syntax file does not.
+* It needs no ODK, no Docker and no ROBOT, which keeps the contributor setup to `uv`.
+
+Deliberately stdlib-only: nothing here may add a dependency, because the dependency set for
+graph work is decided in MH-04 and this must not front-run it.
+
+Usage:
+    python extract_terms.py            # regenerate terms.csv from the pinned commit
+    python extract_terms.py --check    # exit 1 if terms.csv differs from the pin (for CI)
+    python extract_terms.py --latest   # report drift between the pin and MHPO's develop HEAD
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).parent
+PIN = HERE / "pin.txt"
+OUT = HERE / "terms.csv"
+
+REPO = "OpenEnergyPlatform/municipal-heat-planning-ontology"
+EDIT_PATH = "src/ontology/mhpo-edit.owl"
+BRANCH = "develop"  # MHPO's default branch; it has no `main`, despite its ODK config
+
+# IRI prefix -> short source name. Order matters: first match wins.
+SOURCES = [
+    ("https://purl.org/mhpo/ontology/", "mhpo"),
+    ("http://purl.obolibrary.org/obo/BFO_", "bfo"),
+    ("http://purl.obolibrary.org/obo/IAO_", "iao"),
+    ("http://purl.obolibrary.org/obo/RO_", "ro"),
+    ("http://purl.obolibrary.org/obo/", "obo"),
+    ("https://www.commoncoreontologies.org/", "cco"),
+    ("https://openenergyplatform.org/ontology/oeo/", "oeo"),
+]
+
+# Vocabulary terms that are never citable as domain terms. Excluded from the list entirely
+# so that "is this IRI in terms.csv?" is a usable check rather than one with caveats.
+INFRASTRUCTURE = (
+    "http://www.w3.org/2002/07/owl#",
+    "http://www.w3.org/2000/01/rdf-schema#",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "http://www.w3.org/2001/XMLSchema#",
+    "http://purl.org/dc/elements/1.1/",
+    "http://purl.org/dc/terms/",
+)
+
+REPLACED_BY = "http://purl.obolibrary.org/obo/IAO_0100001"
+
+RE_DECL = re.compile(r"Declaration\((\w+)\(<([^>]+)>\)\)")
+RE_LABEL = re.compile(r'AnnotationAssertion\(rdfs:label <([^>]+)> "((?:[^"\\]|\\.)*)"')
+RE_DEPRECATED = re.compile(r'AnnotationAssertion\(owl:deprecated <([^>]+)> "true"')
+RE_REPLACED = re.compile(rf"AnnotationAssertion\(<{re.escape(REPLACED_BY)}> <([^>]+)> <([^>]+)>")
+RE_OBJPROP_USE = re.compile(r"Object(?:Some|All)ValuesFrom\(<([^>]+)>")
+RE_IRI = re.compile(r"<([^>]+)>")
+
+AXIOM_PREFIXES = (
+    "SubClassOf(", "EquivalentClasses(", "DisjointClasses(", "SubObjectPropertyOf(",
+    "ObjectPropertyDomain(", "ObjectPropertyRange(", "ClassAssertion(",
+)
+
+
+def read_pin() -> str:
+    for line in PIN.read_text(encoding="utf-8").splitlines():
+        if line.startswith("commit:"):
+            return line.split(":", 1)[1].strip()
+    sys.exit(f"no 'commit:' line in {PIN}")
+
+
+def fetch(ref: str) -> str:
+    url = f"https://raw.githubusercontent.com/{REPO}/{ref}/{EDIT_PATH}"
+    with urllib.request.urlopen(url, timeout=60) as r:  # noqa: S310 - fixed https host
+        return r.read().decode("utf-8")
+
+
+def source_of(iri: str) -> str:
+    for prefix, name in SOURCES:
+        if iri.startswith(prefix):
+            return name
+    return "other"
+
+
+def curie(iri: str) -> str:
+    return iri.rsplit("/", 1)[-1].split("#")[-1]
+
+
+def parse(text: str) -> list[dict]:
+    declared: dict[str, str] = {}
+    for kind, iri in RE_DECL.findall(text):
+        declared[iri] = kind
+
+    labels = {iri: lbl for iri, lbl in RE_LABEL.findall(text)}
+    deprecated = set(RE_DEPRECATED.findall(text))
+    replaced = dict(RE_REPLACED.findall(text))
+
+    # Terms used in logical axioms, even when MHPO never declares them. MHPO cites several
+    # RO_* relations it neither declares nor imports; they must still be citable, so they
+    # belong in the list — flagged, not silently dropped.
+    used: set[str] = set()
+    objprops_used: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(AXIOM_PREFIXES):
+            used.update(RE_IRI.findall(stripped))
+            objprops_used.update(RE_OBJPROP_USE.findall(stripped))
+
+    rows = []
+    for iri in sorted(set(declared) | used):
+        if iri.startswith(INFRASTRUCTURE):
+            continue
+        kind = declared.get(iri)
+        if kind is None:
+            kind = "ObjectProperty" if iri in objprops_used else "Class"
+        label = labels.get(iri, "")
+        rows.append(
+            {
+                "curie": curie(iri),
+                "label": label,
+                "type": {"Class": "class", "ObjectProperty": "objectProperty",
+                         "AnnotationProperty": "annotationProperty",
+                         "DataProperty": "dataProperty"}.get(kind, kind.lower()),
+                "source": source_of(iri),
+                "declared_in_mhpo": "yes" if iri in declared else "no",
+                # Imports are unresolved in the editors' file, so external labels are simply
+                # not present. Recorded honestly rather than guessed; resolving them needs
+                # ROBOT and the ODK toolchain this repository deliberately does not require.
+                "label_status": "from_mhpo" if label else "unresolved",
+                "deprecated": "yes" if iri in deprecated else "no",
+                "replaced_by": curie(replaced[iri]) if iri in replaced else "",
+                "iri": iri,
+            }
+        )
+    return rows
+
+
+FIELDS = ["curie", "label", "type", "source", "declared_in_mhpo",
+          "label_status", "deprecated", "replaced_by", "iri"]
+
+
+def render(rows: list[dict]) -> str:
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=FIELDS, lineterminator="\n")
+    w.writeheader()
+    w.writerows(rows)
+    return buf.getvalue()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="regenerate from the pin and fail if terms.csv differs")
+    ap.add_argument("--latest", action="store_true",
+                    help="report drift between the pin and MHPO's develop HEAD")
+    args = ap.parse_args()
+
+    if args.latest:
+        pin = read_pin()
+        url = f"https://api.github.com/repos/{REPO}/commits/{BRANCH}"
+        with urllib.request.urlopen(url, timeout=60) as r:  # noqa: S310
+            head = json.load(r)["sha"]
+        if head == pin:
+            print(f"up to date: pin == {BRANCH} HEAD ({pin[:7]})")
+            return 0
+        old = {r["iri"] for r in parse(fetch(pin))}
+        new_rows = parse(fetch(head))
+        new = {r["iri"] for r in new_rows}
+        print(f"MHPO moved: pin {pin[:7]} -> {BRANCH} HEAD {head[:7]}")
+        print(f"  +{len(new - old)} terms, -{len(old - new)} terms")
+        for iri in sorted(new - old):
+            lbl = next((r["label"] for r in new_rows if r["iri"] == iri), "")
+            print(f"  + {curie(iri):18} {lbl}")
+        for iri in sorted(old - new):
+            print(f"  - {curie(iri)}")
+        # Drift is information, not a failure: MHPO is owned by other people and moves often.
+        return 0
+
+    rendered = render(parse(fetch(read_pin())))
+
+    if args.check:
+        if not OUT.exists():
+            print(f"{OUT.name} is missing", file=sys.stderr)
+            return 1
+        if OUT.read_text(encoding="utf-8") != rendered:
+            print(f"{OUT.name} does not match the pinned MHPO commit.\n"
+                  f"Run: python {Path(__file__).name}", file=sys.stderr)
+            return 1
+        print(f"{OUT.name} matches the pin")
+        return 0
+
+    OUT.write_text(rendered, encoding="utf-8")
+    print(f"wrote {OUT.name}: {rendered.count(chr(10)) - 1} terms")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mhpkg/mhpo/pin.txt
+++ b/mhpkg/mhpo/pin.txt
@@ -1,0 +1,11 @@
+# The MHPO commit this repository's term list was generated from.
+#
+# MHPO has no releases and no tags, so a commit SHA is the only pin available.
+# Update with: python extract_terms.py --latest   (to see what moved)
+#              edit commit: below, then: python extract_terms.py
+
+repo:    OpenEnergyPlatform/municipal-heat-planning-ontology
+branch:  develop
+commit:  34776b699d10c936da05b353b1001548bf92e4b2
+date:    2026-06-29
+subject: Merge pull request #15 from OpenEnergyPlatform/feature-12-regions

--- a/mhpkg/mhpo/terms.csv
+++ b/mhpkg/mhpo/terms.csv
@@ -1,0 +1,49 @@
+curie,label,type,source,declared_in_mhpo,label_status,deprecated,replaced_by,iri
+BFO_0000023,,class,bfo,no,unresolved,no,,http://purl.obolibrary.org/obo/BFO_0000023
+BFO_0000050,,objectProperty,bfo,no,unresolved,no,,http://purl.obolibrary.org/obo/BFO_0000050
+BFO_0000051,,objectProperty,bfo,yes,unresolved,no,,http://purl.obolibrary.org/obo/BFO_0000051
+IAO_0000104,,class,iao,yes,unresolved,no,,http://purl.obolibrary.org/obo/IAO_0000104
+IAO_0000115,definition,annotationProperty,iao,yes,from_mhpo,no,,http://purl.obolibrary.org/obo/IAO_0000115
+IAO_0000118,alternative label,annotationProperty,iao,yes,from_mhpo,no,,http://purl.obolibrary.org/obo/IAO_0000118
+RO_0000052,,objectProperty,ro,no,unresolved,no,,http://purl.obolibrary.org/obo/RO_0000052
+RO_0000053,,objectProperty,ro,no,unresolved,no,,http://purl.obolibrary.org/obo/RO_0000053
+RO_0000087,,objectProperty,ro,no,unresolved,no,,http://purl.obolibrary.org/obo/RO_0000087
+OEO_00360020,,class,oeo,no,unresolved,no,,https://openenergyplatform.org/ontology/oeo/OEO_00360020
+MHPO_00020003,municipal heat plan,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020003
+MHPO_00020005,aggregated inventory analysis,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020005
+MHPO_00020006,aggregated potential analysis,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020006
+MHPO_00020007,target scenario,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020007
+MHPO_00020008,implementation measure,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020008
+MHPO_00020009,role of region in municipal heat plan,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020009
+MHPO_00020010,municipality area role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020010
+MHPO_00020011,heat plan area role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020011
+MHPO_00020012,unallocated heat supply subarea role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020012
+MHPO_00020013,heat plan subarea role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020013
+MHPO_00020014,excluded area role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020014
+MHPO_00020016,energy saving area role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020016
+MHPO_00020017,municipality area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020017
+MHPO_00020018,heat plan area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020018
+MHPO_00020019,heat plan subarea,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020019
+MHPO_00020020,unallocated heat supply subarea,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020020
+MHPO_00020021,area for decentralized heat supply,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020021
+MHPO_00020022,role of area for decentralized heat supply,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020022
+MHPO_00020023,role of district heating development area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020023
+MHPO_00020024,role of district heating densification area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020024
+MHPO_00020025,role of district heating expansion area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020025
+MHPO_00020026,projected heat plan subarea,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00020026
+MHPO_00030001,implementation strategy,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030001
+MHPO_00030005,hydrogen grid area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030005
+MHPO_00030006,hydrogen grid area role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030006
+MHPO_00030007,district heating area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030007
+MHPO_00030008,district heating area role,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030008
+MHPO_00030009,district heating densification area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030009
+MHPO_00030010,district heating expansion area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030010
+MHPO_00030011,district heating development area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030011
+MHPO_00030012,energy saving area,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030012
+MHPO_00030013,area under suitability assessment,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030013
+MHPO_00030014,role of area under suitability assessment,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030014
+MHPO_00030016,area excluded from heat planning,class,mhpo,yes,from_mhpo,no,,https://purl.org/mhpo/ontology/MHPO_00030016
+ont00000476,,class,cco,no,unresolved,no,,https://www.commoncoreontologies.org/ont00000476
+ont00000853,,class,cco,no,unresolved,no,,https://www.commoncoreontologies.org/ont00000853
+ont00000965,,class,cco,no,unresolved,no,,https://www.commoncoreontologies.org/ont00000965
+ont00000974,,class,cco,no,unresolved,no,,https://www.commoncoreontologies.org/ont00000974


### PR DESCRIPTION


## Summary of the discussion

MHPO is the T-Box: this repository cites its terms and defines none. To cite them safely it needs to know which terms exist, at a known version.

MHPO has no releases and no tags, and https://purl.org/mhpo redirects to the repository's GitHub page rather than to an ontology -- term IRIs 404. The only consumable artifact is mhpo-edit.owl on a branch, so the pin is a commit SHA.

Vendors a generated term list rather than the ontology itself: it is what the LinkML schema actually needs, it diffs one line per term instead of 57 KB of OWL functional syntax, and it needs no ODK, Docker or ROBOT -- so graph work stays a `uv sync` away. The extractor is stdlib-only so it does not front-run the dependency decisions in MH-04.

48 terms at pin 34776b6: 34 MHPO classes plus the 14 external terms its axioms cite. MHPO mints no relations of its own -- correct OBO practice -- so slots will point at RO and BFO, which is why the list covers what MHPO *uses* and not only what it declares.

Two checks, deliberately separate: --check regenerates from the pin and must match, so it can never fail because MHPO moved; --latest compares the pin to develop HEAD and only reports, since MHPO is owned by other people and moves often. Verified with a negative control -- a corrupted row makes --check exit 1.

Deprecated terms will fail the check and name the successor rather than being followed automatically, because a replacement can be narrower, broader or a split. No MHPO term is deprecated at this pin, so that path is untested.

Records two upstream problems without working around them: MHPO cites RO_* relations it neither declares nor imports, and its ODK config targets a `main` branch that does not exist.

## Type of change (CHANGELOG.md)

### Added
- Add a new class [(#)](https://github.com/OpenEnergyPlatform/oekg/pull/)

### Updated
- Update a definition [(#)](https://github.com/OpenEnergyPlatform/oekg/pull/)

### Removed
- Remove a broken link [(#)](https://github.com/OpenEnergyPlatform/oekg/pull/)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](CHANGELOG.md)
- [ ] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
