### PR TITLE
Add the first cut of the LinkML schema for one MHPKG slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Here is a template for new release sections:
 - `mhpkg/` for the Municipal Heat Planning KG — provisional name [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]
 - Dependency management with uv: `pyproject.toml`, `uv.lock`, `.python-version` [[#51](https://github.com/OpenEnergyPlatform/oekg/pull/51)]
 - Contributor setup instructions in CONTRIBUTING.md
+- `mhpkg/schema/`: first cut of the MHPKG data shape — a LinkML schema for one slice (a municipal
+  heat plan, its target scenario and one final energy consumption value), the SHACL shapes generated
+  from it, a hand-written companion file enforcing the IRI policy, and a passing plus a deliberately
+  failing example instance [[#54](https://github.com/OpenEnergyPlatform/oekg/pull/54)]
 
 ### Changed
 - Repository restructured around two knowledge graphs; OEKG files grouped by status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,8 +120,11 @@ where MHPKG data lives in Fuseki — which datasets, which named graphs — is s
    `uv run mkdocs build --strict` before pushing rather than discovering it in a red pipeline.
 3. **The default branch is `production`** — not `main`, not `develop`. See the note under
    *Permanent branches* below.
-4. **`mhpkg` is a provisional name.** Do not bake it into IRIs, prefixes or published URLs without
-   a rename path.
+4. **`mhpkg` is settled, not provisional.** **Note for anyone who read this before 2026-08-13:** it
+   used to warn against baking `mhpkg` into IRIs, prefixes or published URLs. That is superseded —
+   the name is fixed, instance data lives under `https://openenergyplatform.org/id/mhpkg/` and named
+   graphs under `https://openenergyplatform.org/graph/mhpkg/`, and `mhpkg/schema/` now depends on
+   exactly those namespaces. What *is* still provisional is the internal layout of `mhpkg/`.
 5. **Never hand-edit `uv.lock`.** Change `pyproject.toml`, run `uv lock`, and commit both in the
    same commit. Pull-request checks run `uv lock --check`, which *fails* when the two disagree
    rather than silently re-resolving. **Note for anyone who read this before 2026-08-07:** it used

--- a/docs/mhpkg/index.md
+++ b/docs/mhpkg/index.md
@@ -13,32 +13,57 @@ values for specific attributes can be queried across all of them at once — rat
 locked inside several hundred PDFs. There is substantial interest in this from energy research,
 because planning and modelling work can build directly on such a dataset.
 
-!!! warning "Provisional name"
+!!! info "The name is settled"
 
-    `mhpkg` is a **working name** for both the directory and the graph, and it may change. Nothing
-    should bake it into IRIs, namespace prefixes or published URLs without a rename path.
+    `mhpkg` was a working name and is now **fixed**. It is safe in IRIs, prefixes and published
+    URLs — instance data lives under `https://openenergyplatform.org/id/mhpkg/` and named graphs
+    under `https://openenergyplatform.org/graph/mhpkg/`. No rename path is owed.
 
-## Status: early draft
+## Status: early, but no longer only a sketch
 
 Being honest about maturity, because the ambition above is much larger than what exists today:
 
 | | |
 |---|---|
-| **Model** | one draft, `mhpkg/model/mhpkg_model_first_draft.owl` |
-| **Size** | 350 lines of RDF/XML — 21 classes, 16 object properties, no datatype properties |
-| **Origin** | exported from [Termboard](https://termboard.com/), a visual knowledge-modelling tool |
-| **SHACL shapes** | none yet — the draft contains zero `sh:NodeShape` |
+| **Data shape** | one slice authored in [LinkML](https://linkml.io/) — `mhpkg/schema/` |
+| **Coverage** | a municipal heat plan, its target scenario, and one final energy consumption value |
+| **SHACL shapes** | **generated** from the LinkML schema, plus a hand-written file enforcing the IRI policy |
+| **Terms** | cited from MHPO and OEO, never minted here — pinned term list in `mhpkg/mhpo/` |
+| **Examples** | one conformant instance and one deliberately failing one |
+| **Termboard draft** | `mhpkg/model/mhpkg_model_first_draft.owl` — 350 lines of RDF/XML, kept as a thinking artifact |
 | **Extracted data** | none yet in the graph |
-| **Store** | not yet decided |
+| **Store** | decided — its own Fuseki dataset, one named graph per heat plan. Not yet provisioned |
 
-Two things about the draft that are known and unresolved:
+The two graphs are authored differently on purpose, and the split is the thing to understand:
 
-- Its **base IRI is a vendor namespace** — `https://termboard.com/ontology/…` — because it came
-  out of the modelling tool that way. It needs rebasing onto a namespace this project controls.
-- Its `dc:title` is still `"Imported Document"`.
+- **MHPO owns the vocabulary.** Every class and slot in the LinkML schema carries a `class_uri` or
+  `slot_uri` pointing at a term MHPO or OEO already declares. A term that does not exist becomes an
+  **MHPO term request**, not a new element here — so this repository never becomes a second,
+  competing definition of the same domain.
+- **LinkML owns the shape.** Required fields, cardinality, value ranges and controlled vocabularies
+  are data constraints, and an ontology does not assert them: OWL is open-world. Generating the
+  shapes from MHPO instead was tried on paper and rejected for exactly that reason — the result
+  would validate very little.
 
-Neither is an oversight to be fixed casually: choosing the namespace is a modelling decision, and
-it is recorded rather than quietly patched.
+### Where to look in the repository
+
+[`mhpkg/schema/`](https://github.com/OpenEnergyPlatform/oekg/tree/production/mhpkg/schema) — its
+README carries the commands, the tool versions, and a frank account of what the first slice
+established *and where the approach has limits*. Read that before extending the schema; two of the
+limits change how the generated artifacts can be checked.
+
+[`mhpkg/mhpo/`](https://github.com/OpenEnergyPlatform/oekg/tree/production/mhpkg/mhpo) — the pinned
+MHPO term list, and the script that regenerates it. MHPO has no releases or tags, so the pin is a
+commit SHA.
+
+### About the Termboard draft
+
+It remains in the repository as a record of early modelling, and it is **never machine-consumed**.
+Two reasons, both verified: its base IRI is a vendor namespace (`https://termboard.com/ontology/…`)
+and its `dc:title` is still `"Imported Document"`; and it silently strips umlauts from IRI local
+names, so `Kassel Wärme Ingenieurbüro` becomes `Kassel_Wrme_Ingenieurbro`. Fed through the IRI
+policy, an umlaut-stripped name mints a **different** entity without raising an error. Terms reach
+the model by hand, through MHPO's term-request process.
 
 ## How the data gets here
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -117,21 +117,47 @@ authoring layer: one schema definition generates the SHACL shapes that validate 
 (MHPO) or by OEO — and OWL generation stays off, so it never competes with MHPO as a source of
 terms.
 
-The toolchain for this is now installed and locked, in the `schema` and `graph` groups above.
-**The schema itself does not exist yet**, so nothing in this repository generates shapes today —
-`gen-shacl` works but has nothing to point at. Authoring it is the next step, and it is being
-worked as a separate effort.
+✅ **A first slice of that schema now exists** — `mhpkg/schema/`, covering a municipal heat plan, its
+target scenario and one final energy consumption value, with the SHACL generated from it and both a
+conformant and a deliberately failing example. It was built to test the decision against a real
+OBO-style ontology rather than to cover the domain, and the decision held: `gen-shacl` puts each
+`class_uri` straight into `sh:targetClass`, so the generated shapes constrain MHPO and OEO IRIs
+directly.
+
+Two limits found while building it are worth knowing before relying on the approach, and both are
+documented in `mhpkg/schema/README.md`:
+
+- **The IRI policy cannot be generated.** SHACL constrains a node's own IRI with `sh:pattern` at
+  *node* level and LinkML cannot emit that, so one hand-written shapes file sits alongside the
+  generated one. "Everything is generated" is not achievable today.
+- **Generated SHACL is not byte-stable**, because every `sh:property` is a blank node. A drift check
+  has to compare graphs, not bytes — a `diff` would fail on every run while nothing was wrong.
 
 ### What validates what
 
-⚠️ **No SHACL file in this repository validates any live graph.** Every one of them was authored
-against a dump:
+⚠️ **No SHACL file in this repository validates a live graph**, and that is still true — the new
+shapes validate example files, not the store.
 
-- `oekg/shapes/` — the most developed shapes available, written against the thesis-reworked graph
+Authored against a dump, and untouched:
+
+- `oekg/shapes/` — the most developed OEKG shapes, written against the thesis-reworked graph
 - `oekg/eval/oekg_shacl.txt` — evaluation shapes for the same era
 - the archive's own copies — thesis provenance
 
-So `pyshacl` "working" does not mean there is a validation pipeline. There is not one yet.
+⚠️ Those OEKG shapes also **cannot match the live graph even in principle**: they declare the OEO
+prefix as `http://openenergy-platform.org/ontology/oeo/` and use readable property names like
+`oeo:covers_energy_carrier` that OEO does not define. The namespace resolves — it redirects — but an
+IRI is *identity, not an address*, so every term in them is a different term from the one OEO mints.
+See the namespace-migration note below.
+
+Authored against the schema, and exercised on every run of `mhpkg/schema/validate.py`:
+
+- `mhpkg/schema/generated/` — generated from the LinkML schema
+- `mhpkg/schema/mhpkg_iri_policy.shacl.ttl` — hand-written, enforcing the IRI policy
+
+So `pyshacl` "working" now means example data is checked in both directions — the conformant
+instance passes and the negative control is asserted to fail for each of its reasons. It does **not**
+yet mean there is a validation pipeline, or a CI job.
 
 ### Namespace migration
 
@@ -154,22 +180,24 @@ separate instance. Access, backup and governance ride on the answer.
 **Undecided.** Which extracted heat-plan data belongs in the graph as triples, and which is better
 served as a table on the Open Energy Platform. See [Workflow](workflow.md#not-everything-belongs-in-a-graph).
 
-## The modelling and build workflow — planned, not built
+## The modelling and build workflow — the first steps built
 
-!!! danger "This diagram describes an intention, not reality"
+!!! warning "The left of this diagram is real; the right is still intention"
 
-    **None of the pipeline below exists today.** It is drawn to make the open decisions visible and
-    to give the shapes-first work a starting point to argue with — not to record an agreed design.
-    The boxes marked *undecided* are the actual open questions listed above.
+    **The authoring end now exists** — a LinkML schema, the SHACL generated from it, and validation
+    of example data in both directions. Solid boxes below are built and exercised.
 
-    Do not treat this as the agreed pipeline. When a decision is made, the marker in this diagram
-    should be replaced by the answer.
+    **Nothing has been loaded into a triple store yet**, and there is no CI job. Dashed boxes are
+    not built. The boxes still marked *undecided* are the open questions listed above.
+
+    When a decision is made, the marker here should be replaced by the answer rather than left to
+    rot.
 
 ```mermaid
 flowchart LR
-    SRC["Model source of truth<br/>SHACL-first or LinkML<br/>UNDECIDED"]
+    SRC["Model source of truth<br/>LinkML — DECIDED"]
     GEN["Generated artifacts<br/>what exactly: UNDECIDED"]
-    SHAPES["SHACL shapes"]
+    SHAPES["SHACL shapes<br/>generated + hand-written IRI policy"]
     DATA["Graph data"]
     VAL["Validation<br/>pyshacl"]
     LOAD["Load into Fuseki"]
@@ -180,11 +208,18 @@ flowchart LR
     DATA --> VAL
     VAL -- passes --> LOAD
     VAL -- fails --> SRC
+
+    classDef built stroke-width:2px
+    classDef todo stroke-dasharray: 5 5
+    class SRC,SHAPES,VAL built
+    class GEN,DATA,LOAD todo
 ```
 
 The shape of it is not controversial — author a model, generate from it, validate data against it,
-load what passes. What is undecided is **what the leftmost box actually is**, and that determines
-everything downstream.
+load what passes. **The leftmost box is now answered**: LinkML authors the model, MHPO owns the
+terms. What remains open is *which* generated artifacts are authoritative and how they are published
+— and one finding from building the schema constrains that answer already, because the IRI policy
+has to be hand-written, so the contract cannot simply say "everything is generated".
 
 ## Documentation and CI
 

--- a/mhpkg/README.md
+++ b/mhpkg/README.md
@@ -11,13 +11,15 @@ separately from, the OEKG**, which occupies [its own area](../oekg/) of this rep
 describes energy studies and scenarios. The two graphs share a repository, not a model. See the
 [root README](../README.md) for how the repository is laid out and why there is no `shared/`.
 
-## ⚠️ `mhpkg` is a provisional name
+## ✅ The name `mhpkg` is settled
 
-The directory name and the short name `mhpkg` are **provisional** and may change.
+It was provisional; it is now fixed, and it is **safe to bake in**. Instance data lives under
+`https://openenergyplatform.org/id/mhpkg/` and named graphs under
+`https://openenergyplatform.org/graph/mhpkg/`. No rename path is owed.
 
-**Do not bake `mhpkg` into anything expensive to change** — in particular not IRIs, not
-namespace prefixes, and not published URLs. If you need a prefix while working on the
-draft, use a clearly temporary one and keep it in a single place so a rename is one edit.
+> ⚠️ **If you read an earlier version of this file**, it warned against putting `mhpkg` into IRIs,
+> prefixes or published URLs. That warning is superseded — the schema in [`schema/`](schema/) now
+> depends on exactly those namespaces.
 
 ## What belongs in here
 
@@ -27,16 +29,24 @@ draft, use a clearly temporary one and keep it in a single place so a rename is 
 
 ## Current layout
 
-Only one directory exists, because there is only one thing to put anywhere:
+Three directories, each created when there was something to put in it:
 
 | Path | Contents |
 |---|---|
-| `mhpkg/model/mhpkg_model_first_draft.owl` | the first draft of the model — 350 lines of RDF/XML exported from [Termboard](https://termboard.com/): 21 `owl:Class`, 16 `owl:ObjectProperty`, no `owl:DatatypeProperty`, no `sh:NodeShape` |
+| [`schema/`](schema/) | **the data shape** — the LinkML schema, the SHACL generated from it, the hand-written IRI-policy shapes, and worked examples. Start here |
+| [`mhpo/`](mhpo/) | the pinned MHPO term list — which terms this graph may cite, and the commit they came from |
+| `model/mhpkg_model_first_draft.owl` | the original Termboard draft — 350 lines of RDF/XML, 21 `owl:Class`, 16 `owl:ObjectProperty`, no `owl:DatatypeProperty`, no `sh:NodeShape` |
 
-`model/` rather than `shapes/` because the draft is **OWL, not SHACL** — it contains zero
-`sh:NodeShape`, so the shapes-first intent is not yet reflected in it. The name is
-**provisional** and may be revised when the model source of truth is decided (see the open
-questions below).
+`model/` is named for its contents: that file is **OWL, not SHACL**. The shapes now live in
+[`schema/generated/`](schema/generated/) and are generated rather than hand-written.
+
+> ⚠️ **The Termboard draft is a thinking artifact and is never machine-consumed.** Beyond the
+> vendor base IRI and the `"Imported Document"` title, it declares everything as `owl:Class` —
+> values, units and individuals alike — and silently strips umlauts from IRI local names, so
+> `Kassel Wärme Ingenieurbüro` becomes `Kassel_Wrme_Ingenieurbro`. Fed through the IRI policy that
+> mints a **different** entity with no error. Terms reach the model by hand, as MHPO term requests.
+
+⚠️ These directory names and this layout are **provisional** — see open question 3 below.
 
 Directory names are shared with the OEKG's area *where both graphs genuinely have the same
 thing* — `shapes/`, `eval/`, `examples/` are the agreed vocabulary. No parallel structure is
@@ -77,24 +87,31 @@ municipal-heat-planning-pdf-processing   (RAG pipeline: vocabulary + content ext
 municipal-heat-planning-ontology (MHPO)  ──uses──▶  Open Energy Ontology (OEO)
         │
         ▼
-   mhpkg  (this directory)  ──loaded into──▶  Jena Fuseki dataset  ◀── which dataset: open
+   mhpkg  (this directory)  ──loaded into──▶  Jena Fuseki dataset `mhpkg`
 ```
 
-The Open Energy Platform already serves the OEKG from a Jena Fuseki store over SPARQL.
-Whether `mhpkg` becomes a second dataset in that same store or gets its own instance is
-**not yet decided**.
+The Open Energy Platform already serves the OEKG from a Jena Fuseki store over SPARQL. MHPKG gets
+**its own dataset beside it**, holding one named graph per heat plan, so re-loading a plan is an
+atomic whole-graph replace and a re-run updates rather than duplicates. ⚠️ **The dataset does not
+exist yet** — the layout is decided, not provisioned.
 
 ## Open questions this scaffold deliberately does not answer
 
-These are being worked separately. Please do not settle them by implication in the draft —
-if the draft forces a position on one, say so rather than letting the commit decide it.
+These are being worked separately. Please do not settle them by implication —
+if a change forces a position on one, say so rather than letting the commit decide it.
 
-1. **The model source of truth.** SHACL-shapes-first is the intended direction, and LinkML
-   is under consideration as the authoring layer to generate from. Not yet decided.
+1. ✅ ~~**The model source of truth.**~~ **Decided.** [LinkML](https://linkml.io/) authors the data
+   shape and generates the SHACL; MHPO remains the only source of *terms*. See
+   [`schema/`](schema/) for the schema and for what the first slice established — including where
+   the approach has known limits.
 2. **The KG / table boundary.** Which extracted data belongs in the graph as triples versus
    in a table on the Open Energy Platform.
-3. **The Fuseki dataset** that will host this graph.
-4. **This directory's final name and internal layout.**
+3. ⚠️ **This directory's internal layout** — the names `schema/`, `mhpo/` and `model/`, and where the
+   IRI-policy document finally lives. The *graph's* name is settled (`mhpkg`); only the layout is
+   open.
+
+Previously listed here and now answered: **the Fuseki dataset** — MHPKG gets its own, as described
+above.
 
 ## Licence
 

--- a/mhpkg/schema/README.md
+++ b/mhpkg/schema/README.md
@@ -31,7 +31,8 @@ Both were decided before this schema existed and neither is reopenable here.
 | [`generated/mhpkg_target_scenario.shacl.ttl`](generated/) | **generated.** Do not hand-edit |
 | [`mhpkg_iri_policy.shacl.ttl`](mhpkg_iri_policy.shacl.ttl) | **hand-written.** The IRI policy as shapes — LinkML cannot express it |
 | [`mint_slice.py`](mint_slice.py) | mints the example IRIs, so no UUID in this directory is hand-typed |
-| [`validate.py`](validate.py) | validates both examples and **asserts the negative control catches every case** |
+| [`validate.py`](validate.py) | validates both examples and **asserts the negative control catches every case**. Needs `graph` only |
+| [`check_generated.py`](check_generated.py) | checks the committed SHACL still matches the schema. Needs `schema` |
 | [`examples/kassel_valid.ttl`](examples/kassel_valid.ttl) | a conformant instance |
 | [`examples/kassel_invalid.ttl`](examples/kassel_invalid.ttl) | the negative control — every node wrong in a different way |
 
@@ -46,11 +47,29 @@ uv run gen-shacl --closed mhpkg/schema/mhpkg_target_scenario.yaml \
 
 uv run python mhpkg/schema/mint_slice.py   # print the slice's IRIs and how they are derived
 uv run python mhpkg/schema/validate.py     # validate; exit 0 only if the negative control holds
+
+# check the committed SHACL still matches the schema (needs the `schema` group — it regenerates)
+uv run --group schema python mhpkg/schema/check_generated.py
 ```
 
 Verified with linkml 1.11.1, pyshacl 0.40.1, rdflib 7.6.0, against MHPO at pin
 [`34776b6`](../mhpo/pin.txt) and OEO 2.13.0.
 
+> 🔴 **Do not check the generated file with a byte diff.** `gen-shacl` output is **not byte-stable
+> across runs**: every `sh:property` is a blank node and rdflib mints fresh blank-node ids per
+> process, so the property blocks come out in a different order each time. Measured — three
+> consecutive runs of the same unchanged schema produced three different SHA-256 sums, and
+> `PYTHONHASHSEED=0` does **not** fix it (three more runs, three more sums), so this is blank-node id
+> generation rather than dict ordering.
+>
+> A `diff`-based drift check — the obvious design, and the one `mhpkg/mhpo/extract_terms.py --check`
+> uses for `terms.csv` — would therefore fail on **every** run while nothing was wrong, which is
+> worse than no check at all. `check_generated.py` compares **graph-isomorphically** instead
+> (`rdflib.compare.to_isomorphic`), and reports the concrete constraint that differs rather than the
+> raw set difference, which after canonicalisation names nothing a human can act on.
+>
+> It also fails when the generator **logs an error while succeeding** — see the exit-0 trap below.
+>
 > ⚠️ **Do not validate with two `-s` flags.** `pyshacl` accepts repeated `-s` and **silently uses
 > only the last one** — the earlier shapes graph is discarded with no warning. This was hit while
 > building the slice: `pyshacl -s generated/… -s mhpkg_iri_policy.… kassel_valid.ttl` reported

--- a/mhpkg/schema/README.md
+++ b/mhpkg/schema/README.md
@@ -1,0 +1,178 @@
+# The MHPKG data shape
+
+**LinkML authors the data shape; MHPO owns the ontology.** This directory holds the LinkML schema
+for MHPKG, the SHACL shapes generated from it, and worked examples that prove the shapes reject
+what they should.
+
+> **Status: first cut, one slice.** It covers a municipal heat plan, the target scenario inside it
+> and one final energy consumption value — deep enough to be honest, small enough to finish. It is
+> not the schema for the whole domain, and the [findings](#what-this-slice-established) below matter
+> more than the coverage.
+>
+> **This directory's location is provisional.** **MH-03** decides the `mhpkg/` layout and may move
+> it, as it may move [`../mhpo/`](../mhpo/).
+
+## The two guardrails
+
+Both were decided before this schema existed and neither is reopenable here.
+
+1. **LinkML never mints domain terms.** Every class carries a `class_uri` and every slot a
+   `slot_uri` pointing at a term MHPO or OEO already declares. A needed term that does not exist is
+   an **MHPO term request**, not a new LinkML element — see [Term requests](#term-requests-open).
+2. **`gen-owl` stays off.** MHPO owns the OWL rendering of this domain. A second one generated here
+   would be two competing definitions of one domain, which is the duplication the single-T-Box
+   decision exists to prevent.
+
+## Files
+
+| Path | What it is |
+|---|---|
+| [`mhpkg_target_scenario.yaml`](mhpkg_target_scenario.yaml) | the schema — **the only thing you edit** |
+| [`generated/mhpkg_target_scenario.shacl.ttl`](generated/) | **generated.** Do not hand-edit |
+| [`mhpkg_iri_policy.shacl.ttl`](mhpkg_iri_policy.shacl.ttl) | **hand-written.** The IRI policy as shapes — LinkML cannot express it |
+| [`mint_slice.py`](mint_slice.py) | mints the example IRIs, so no UUID in this directory is hand-typed |
+| [`validate.py`](validate.py) | validates both examples and **asserts the negative control catches every case** |
+| [`examples/kassel_valid.ttl`](examples/kassel_valid.ttl) | a conformant instance |
+| [`examples/kassel_invalid.ttl`](examples/kassel_invalid.ttl) | the negative control — every node wrong in a different way |
+
+## Commands
+
+```bash
+uv sync --group schema --group graph        # linkml (88 pkgs) + pyshacl and rdflib (11)
+
+# regenerate the shapes; commit the YAML and the generated file together
+uv run gen-shacl --closed mhpkg/schema/mhpkg_target_scenario.yaml \
+  > mhpkg/schema/generated/mhpkg_target_scenario.shacl.ttl
+
+uv run python mhpkg/schema/mint_slice.py   # print the slice's IRIs and how they are derived
+uv run python mhpkg/schema/validate.py     # validate; exit 0 only if the negative control holds
+```
+
+Verified with linkml 1.11.1, pyshacl 0.40.1, rdflib 7.6.0, against MHPO at pin
+[`34776b6`](../mhpo/pin.txt) and OEO 2.13.0.
+
+> ⚠️ **Do not validate with two `-s` flags.** `pyshacl` accepts repeated `-s` and **silently uses
+> only the last one** — the earlier shapes graph is discarded with no warning. This was hit while
+> building the slice: `pyshacl -s generated/… -s mhpkg_iri_policy.… kassel_valid.ttl` reported
+> `Conforms: True` and exit 0 while consulting neither, and still reported conformance after a
+> required label was deleted. `validate.py` merges the shapes into one graph, which is why it
+> exists instead of a shell one-liner.
+
+## What this slice established
+
+The ticket's premise was that the LinkML-authors-SHACL decision was made on reasoning rather than
+evidence. It holds — with two caveats that are load-bearing.
+
+**✅ The mapping works, and the pivot is `class_uri`.** `gen-shacl` puts the `class_uri` straight
+into `sh:targetClass`, so the generated shapes constrain **MHPO and OEO IRIs directly** rather than
+some LinkML-shaped shadow of them. Nothing is minted and nothing is translated.
+
+**✅ MHPO's reification is not the problem it looked like.** The worry was that BFO-style modelling
+reifies what LinkML would express as a direct slot. In this slice it does not bite, because the two
+halves reify the *same way*: OEO's `quantity value` already hangs the number and the unit off a
+value node, which is exactly what LinkML would do. MHPO's heavy role reification —
+`heat plan area` *bearer of* `heat plan area role` — is real but sits in the **area** subtree, and
+this slice does not enter it. **That is a deferral, not a clearance:** the areas and roles are
+three quarters of MHPO's 34 classes, and the first ticket that models them will meet it.
+
+**✅ Enums are the pattern to reuse.** OEO models units, carriers and sectors as *classes*, but a
+statistic is about the carrier *type*, so pointing at a class IRI is unavoidable punning. A LinkML
+enum whose every `meaning:` is an OEO IRI generates `sh:in` — a real value-set constraint instead
+of `sh:nodeKind sh:IRI`, which accepts any IRI including a carrier pasted into the sector slot.
+This is not invented: `oekg/shapes/oekg_shapes.ttl` already enumerates ~120 OEO class IRIs by hand
+for the same property. The enum reaches the same place from a generated source.
+
+> ⚠️ Those OEKG shapes are otherwise unusable, and it is worth knowing why — though fixing them is
+> out of scope, as the predecessor map settled. They declare `oeo` as
+> `http://openenergy-platform.org/ontology/oeo/` (hyphenated, `http`) and use readable property
+> names like `oeo:covers_energy_carrier` that OEO does not define. The namespace **does** resolve —
+> 200, redirecting to the un-hyphenated host — but IRIs are *identity, not addresses*: OEO mints
+> every term under `https://openenergyplatform.org/ontology/oeo/`, so the hyphenated string is a
+> different term that happens to serve the same page. Resolving is not matching.
+>
+> `linkml-lint` warns that this schema's `oeo` prefix is not canonical and wants the hyphenated
+> form. That is a **stale prefix-registry entry**, not a defect here. The warning is accepted rather
+> than silenced, so `linkml-lint` on this schema reports one known problem.
+
+**🔴 The IRI policy cannot be generated.** SHACL constrains a node's own IRI with `sh:pattern` at
+**node** level, and LinkML has no way to emit that. Measured on linkml 1.11.1:
+
+- a **type-level** `pattern` is dropped — silently when the type has a `uri:`; with a logged
+  `ERROR: No URI for type X` **and exit code 0** when it does not;
+- a **slot-level** `pattern` is emitted correctly;
+- on an `identifier: true` slot it is emitted against `mhpkg_schema:id`, an invented property that
+  appears in no instance triple — well-formed, and it can never fire.
+
+So the machine-checkable half of the IRI policy that MH-02 delegated here lives in a hand-written
+companion file. **This is direct input to MH-07: the generated-artifacts contract cannot say
+"everything is generated".**
+
+**🔴 Enum membership cannot be checked by anything in this repository.** OEO's `energy carrier` has
+four asserted subclasses and all are abstract; `natural gas` is a subclass of `gas mixture` and
+qualifies only *by inference*, through a disposition equivalence axiom. The OEKG's shape file admits
+this in a comment — "energy carrier subclassed and as inferred". Confirming a candidate IRI really
+is a carrier needs a reasoner, and this repository has `pyshacl` and `rdflib`, neither of which
+reasons; MH-01 deliberately kept ROBOT, ODK and Docker out of the contributor setup. The enums are
+hand-curated snapshots that can drift from OEO silently — the drift problem MH-01 solved for MHPO
+terms, recurring one level down. **Input to MH-07 and MH-12.**
+
+**🔴 Two decided policies collide over the municipality.** MH-02 §6 rules that
+`Stadt Kassel, der Bürgermeister` is not a second entity and reuses `municipality/AGS_06611000`. But
+the only class available for that IRI is `municipality area` — a spatial region, and a region cannot
+commission a plan. There is no term anywhere in MHPO or OEO for the municipality as a legal body.
+The IRI shapes make it concrete rather than arguable: the municipality shape requires
+`.../municipality/AGS_<8 digits>` and the organisation shape requires `.../organisation/<UUIDv5>`,
+so **one IRI cannot satisfy both**. Typing it as an organisation is a validation failure, not a
+workaround — which leaves the planning authority absent from the example, and WPG §12 makes it a
+statutory party. **This one needs a human.**
+
+**⚠️ The publication date and three other slots borrow relations whose declared domain is wrong.**
+`covers energy carrier` and `covers sector` declare domain `study`; `has scenario year value`
+declares domain `scenario factsheet` *and* range `xsd:dateTime`; `has publication date` declares
+domain `report`, and MHPO puts a heat plan under `plan specification`. OWL domains are inferential
+rather than constraining, so nothing complains — a reasoner will quietly infer that **every MHPKG
+consumption value is a study**, and SHACL cannot see this at all. Each is annotated at its slot and
+folded into the term requests.
+
+**⚠️ Closed shapes reject provenance.** `--closed` is what stops a pipeline inventing its own
+predicates, and it also rejects *any* extra triple — including which PDF, which page, which model,
+what confidence. Provenance modelling is already fog on the map; case 7 of the negative control is
+where it turns from a modelling question into a validation failure.
+
+**⚠️ German labels must be plain literals.** `range: string` generates `sh:datatype xsd:string`, and
+a `"…"@de` literal has datatype `rdf:langString` — a different datatype, so it is **rejected**. The
+obvious, correct-looking way to mark a German label as German fails. Worth knowing before a RAG
+pipeline emits thousands of them; whether to widen the shape or forbid the tag is MH-07's.
+
+**⚠️ Turtle cannot abbreviate these IRIs.** MH-02's IRIs carry path segments
+(`.../heatplan/AGS_…`), and a Turtle prefixed name may not contain an unescaped `/`. So
+`mhpkg:heatplan/AGS_06611000_2024-03-15` is a **syntax error**, and hand-written instance data must
+use full angle-bracket IRIs. Cosmetic, but it bites immediately and silently looks like a typo.
+
+## Term requests, open
+
+None is worked around in the schema; each appears as a commented `TERM REQUEST` block in
+[`mhpkg_target_scenario.yaml`](mhpkg_target_scenario.yaml) at the position it would occupy, so the
+hole is visible in the artifact. They belong to MHPO's owners — filing is
+[**MH-05**](../mhpo/README.md)'s neighbour, not this ticket's.
+
+1. **Which area a plan is for.** Nothing relates a *plan* to the area it plans. Without it a heat
+   plan cannot say where it applies.
+2. **The municipality as a legal body**, distinct from its territory — the collision above.
+3. **The role a body plays towards a plan.** Planning authority (statutory, WPG §12) versus
+   contracted planner. `has organisation` collapses them into one relation.
+4. **The AGS as data**, not only inside an IRI. A key recoverable by string surgery on an
+   identifier cannot be queried or typed as a key. OEO's `unique individual identifier` is an
+   *annotation* property, so it will not serve.
+5. **Relations from a quantity value to its temporal region, energy carrier and sector** — or the
+   existing `covers …` relations with domains widened past `study`.
+
+## Deliberately not here
+
+- **The rest of the domain.** One slice, done properly.
+- **Which generators are authoritative and how output is published** — that is **MH-07**, and it is
+  downstream of seeing one generator work. It now also inherits three constraints from above: the
+  hand-written companion file, enum drift, and the `@de` question.
+- **Loading anything into Fuseki** — **MH-11**. Nothing here has been near a triple store.
+- **A validation CI job** — **MH-12**. `validate.py` exits non-zero on failure so that job has
+  something to call, but wiring it into `checks.yml` is not this ticket's.

--- a/mhpkg/schema/check_generated.py
+++ b/mhpkg/schema/check_generated.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Check that the committed SHACL still matches the schema it was generated from.
+
+The drift check for `generated/`, in the spirit of `mhpkg/mhpo/extract_terms.py --check`: regenerate
+from the source and compare. Someone editing `mhpkg_target_scenario.yaml` and forgetting to re-run
+`gen-shacl` is the failure this catches.
+
+WHY IT CANNOT BE A BYTE DIFF, which is the obvious way to write it and is wrong here:
+
+    `gen-shacl` output is NOT byte-stable across runs. Every `sh:property` is a blank node, and
+    rdflib mints fresh blank-node ids per process, so the property blocks come out in a different
+    order every time. Measured: three consecutive runs of the same schema produced three different
+    SHA-256 sums. `PYTHONHASHSEED=0` does NOT fix it — three more runs, three more sums — so this is
+    blank-node id generation, not dict-ordering.
+
+    A `diff`-based check would therefore fail on every single run while nothing was wrong, which is
+    worse than no check: it trains people to ignore it.
+
+So the comparison is GRAPH-ISOMORPHIC — `rdflib.compare.to_isomorphic`, which canonicalises blank
+node labels and compares the graphs as graphs. Two serialisations of the same shapes compare equal;
+a genuine change to a constraint does not.
+
+⚠️ This needs the `schema` dependency group (it runs the generator), whereas `validate.py` needs only
+`graph`. That split is deliberate and comes from MH-04: `linkml` is 88 of the 95 packages, and a job
+that only validates data has no reason to install a generator. Keep the two scripts separate for
+that reason — do not fold this into `validate.py`.
+
+The generator runs IN-PROCESS rather than as a subprocess. Two reasons: the `gen-shacl` console
+script is not always on `PATH` even when `linkml` is installed, and running in-process lets this
+script capture the generator's log records directly — which matters, because that is the only way to
+see the failures it reports without failing.
+
+Usage:
+    uv run --group schema python mhpkg/schema/check_generated.py
+Exit codes:
+    0  the committed file is graph-isomorphic to a fresh generation
+    1  it has drifted, or the generator logged an error — re-run gen-shacl and commit the result
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from linkml.generators.shaclgen import ShaclGenerator
+from rdflib import BNode, Graph
+from rdflib.compare import to_isomorphic
+
+HERE = Path(__file__).parent
+SCHEMA = HERE / "mhpkg_target_scenario.yaml"
+COMMITTED = HERE / "generated" / "mhpkg_target_scenario.shacl.ttl"
+
+# `closed=True` must match the `--closed` flag in the README command. It is a deliberate choice
+# rather than a default: closed shapes are what stop a pipeline inventing its own predicates.
+CLOSED = True
+
+
+class ErrorCatcher(logging.Handler):
+    """Collect ERROR-or-worse records emitted while generating.
+
+    `gen-shacl` reports real failures through the logger and STILL SUCCEEDS — a dropped type-level
+    `pattern` logs `No URI for type X` and the process exits 0. So the absence of an exception is not
+    evidence that generation worked, and the log has to be treated as part of the result.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+        self.records: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record.getMessage())
+
+
+def main() -> int:
+    catcher = ErrorCatcher()
+    logging.getLogger().addHandler(catcher)
+    try:
+        turtle = ShaclGenerator(str(SCHEMA), closed=CLOSED).serialize()
+    except Exception as exc:  # noqa: BLE001 — any generator failure is a check failure
+        print(f"generation failed: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        logging.getLogger().removeHandler(catcher)
+
+    if catcher.records:
+        print("the generator logged errors while still succeeding, which it does silently:")
+        for msg in catcher.records:
+            print(f"  {msg}")
+        return 1
+
+    fresh = to_isomorphic(Graph().parse(data=turtle, format="turtle"))
+    committed = to_isomorphic(Graph().parse(COMMITTED, format="turtle"))
+
+    if fresh == committed:
+        print(f"OK — {COMMITTED.relative_to(HERE.parent.parent)} matches the schema "
+              f"({len(committed)} triples, compared as graphs rather than bytes)")
+        return 0
+
+    print(f"DRIFT — {COMMITTED.relative_to(HERE.parent.parent)} does not match {SCHEMA.name}")
+    print(f"  committed: {len(committed)} triples")
+    print(f"  generated: {len(fresh)} triples")
+
+    # Report the CONCRETE differences, not the raw set difference. Canonicalisation relabels every
+    # blank node, so subtracting the isomorphic graphs reports almost the whole file as "changed"
+    # and names nothing a human can act on. Every constraint that matters is a (predicate, object)
+    # pair with a non-blank object — `sh:minInclusive 2024`, `sh:path oeo:OEO_00140178` — so compare
+    # those and let the blank-node scaffolding fall away.
+    def constraints(g: Graph) -> set[tuple[str, str]]:
+        return {
+            (str(p), str(o))
+            for _, p, o in g
+            if not isinstance(o, BNode)
+        }
+
+    c_committed, c_fresh = constraints(committed), constraints(fresh)
+    pairs = (
+        ("in the committed file but not regenerated", sorted(c_committed - c_fresh)),
+        ("regenerated but not in the committed file", sorted(c_fresh - c_committed)),
+    )
+    if any(diff for _, diff in pairs):
+        for label, diff in pairs:
+            if diff:
+                print(f"\n  {label}:")
+                for p, o in diff:
+                    print(f"    {p} {o}")
+    else:
+        print("\n  No constraint differs. The graphs differ only in blank-node structure —")
+        print("  e.g. the same constraints attached to a different number of property shapes.")
+
+    print("\nRe-run the gen-shacl command in mhpkg/schema/README.md and commit the result.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mhpkg/schema/examples/kassel_invalid.ttl
+++ b/mhpkg/schema/examples/kassel_invalid.ttl
@@ -1,0 +1,120 @@
+# THE NEGATIVE CONTROL. Every node below is deliberately wrong, in a different way.
+#
+# A validator that never rejects anything is not evidence. This file exists so that
+# `kassel_valid.ttl` passing means something: each violation here names the constraint it is
+# aimed at, and `validate.py` asserts that all of them are caught.
+#
+# Validate with:
+#   .venv/bin/python mhpkg/schema/validate.py
+#
+# Expected: NON-CONFORMING, with one violation per numbered case below.
+
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo:   <http://purl.obolibrary.org/obo/> .
+@prefix mhpo:  <https://purl.org/mhpo/ontology/> .
+@prefix oeo:   <https://openenergyplatform.org/ontology/oeo/> .
+
+# --- 1. Tier-1: the missing leading zero ----------------------------------------------
+#
+# `AGS_6611000` is seven digits. The Amtlicher Gemeindeschlüssel is eight and the leading zero is
+# significant — `06` is Hessen. This is the single most likely real-world corruption of the whole
+# policy, because every spreadsheet program in existence will strip that zero on import.
+
+<https://openenergyplatform.org/id/mhpkg/municipality/AGS_6611000>
+    a mhpo:MHPO_00020017 ;
+    rdfs:label "Gemeindegebiet Kassel, AGS mit fehlender führender Null" .
+
+# --- 2. Tier-3: a UUIDv4 where the policy requires v5 ---------------------------------
+#
+# The version nibble here is `4`, i.e. random. Reproducibility is the one property the whole
+# pipeline rests on, and a v4 breaks it silently — the data looks perfect and re-running the
+# import duplicates every node. This is the OEKG's actual defect, reproduced on purpose.
+
+<https://openenergyplatform.org/id/mhpkg/organisation/9f1e2d3c-4b5a-4c7d-8e9f-0a1b2c3d4e5f>
+    a oeo:OEO_00030022 ;
+    rdfs:label "Planungsbüro mit UUIDv4 statt v5" .
+
+# --- 3. A non-ASCII instance IRI ------------------------------------------------------
+#
+# The umlaut rule, violated at the output end: German belongs in `rdfs:label`, never in identity.
+
+<https://openenergyplatform.org/id/mhpkg/organisation/Kassel-Wärme-Ingenieurbüro>
+    a oeo:OEO_00030022 ;
+    rdfs:label "Kassel Wärme Ingenieurbüro" .
+
+# --- 4. The plan: a missing publication date, and a language-tagged label -------------
+#
+# TWO violations on one node.
+#
+# (a) No `has publication date`. The generated shape requires exactly one, and it is not fussiness
+#     — the date is the Tier-2 discriminator, so a plan without one has no derivable identity.
+#
+# (b) `"..."@de` instead of a plain literal. This is the German-language question, and the answer
+#     is that IT FAILS: LinkML's `range: string` generates `sh:datatype xsd:string`, and a
+#     language-tagged literal has datatype `rdf:langString`, which is a DIFFERENT datatype. So the
+#     obvious, correct-looking way to mark a German label as German is rejected by the generated
+#     shapes. Worth knowing before a RAG pipeline emits thousands of them.
+
+<https://openenergyplatform.org/id/mhpkg/heatplan/AGS_06611000_2024-03-15>
+    a mhpo:MHPO_00020003 ;
+    rdfs:label "Kommunale Wärmeplanung Kassel 2024"@de ;
+    obo:BFO_0000051 <https://openenergyplatform.org/id/mhpkg/targetscenario/AGS_06611000_2024-03-15> ;
+    oeo:OEO_00000510 <https://openenergyplatform.org/id/mhpkg/organisation/2d4f4ae8-ea0f-575c-9a76-8dcf377042af> .
+
+# --- 5. The scenario: a Tier-2 IRI missing its discriminator --------------------------
+#
+# `targetscenario/AGS_06611000` has no date. WPG §25(1) obliges a review at least every five
+# years, so a municipality will have several scenarios and this IRI cannot say which one it is.
+
+<https://openenergyplatform.org/id/mhpkg/targetscenario/AGS_06611000>
+    a mhpo:MHPO_00020007 ;
+    rdfs:label "Zielszenario ohne Datum" ;
+    oeo:OEO_00140002 <https://openenergyplatform.org/id/mhpkg/value/a878a3a1-b856-5aaf-b767-d1b4154d11aa> .
+
+# --- 6. The value: four violations at once --------------------------------------------
+#
+# (a) A NEGATIVE consumption. `-241.0` — the one constraint in this schema that comes from the
+#     domain rather than from an ontology term, and exactly the kind of thing the rejected
+#     "generate SHACL from MHPO" route could never have produced: OWL is open-world and asserts
+#     nothing about sign.
+#
+# (b) An out-of-vocabulary ENERGY CARRIER. `oeo:OEO_00000132` is `district heating`, which OEO
+#     puts under `grid-bound heating` — a transfer process, not a carrier. A plausible mistake,
+#     and precisely the one the `sh:in` enum exists to reject. A bare `sh:nodeKind sh:IRI` would
+#     have waved it through.
+#
+# (c) A SECTOR IRI that is not a sector at all. `oeo:OEO_00000292` is natural gas — a carrier
+#     pasted into the sector slot. Same class of error, caught by the same mechanism.
+#
+# (d) An OUT-OF-RANGE year. `1990` is before the WPG existed; the schema floors the year at 2024.
+
+<https://openenergyplatform.org/id/mhpkg/value/a878a3a1-b856-5aaf-b767-d1b4154d11aa>
+    a oeo:OEO_00050016 ;
+    oeo:OEO_00140178 "-241.0"^^xsd:float ;
+    oeo:OEO_00040010 oeo:OEO_00050008 ;
+    oeo:OEO_00000523 oeo:OEO_00000132 ;
+    oeo:OEO_00000505 oeo:OEO_00000292 ;
+    oeo:OEO_00020440 "1990"^^xsd:integer ;
+    oeo:OEO_00390023 oeo:OEO_00140070 .
+
+# --- 7. An undeclared property on a declared class ------------------------------------
+#
+# `sh:closed true` is on every generated shape, so a property the schema does not declare is a
+# violation. This is what stops a RAG pipeline from quietly inventing its own predicates and
+# having them accepted because nothing was looking.
+#
+# ⚠️ It is also the constraint most likely to be wrong in production, and the reason is worth
+# recording: closed shapes reject ANY extra triple, including provenance — which PDF, which page,
+# which model, what confidence. That is already on the map as fog, and this line is where it turns
+# from a modelling question into a validation failure.
+
+<https://openenergyplatform.org/id/mhpkg/value/b1c2d3e4-f5a6-5b7c-8d9e-0f1a2b3c4d5e>
+    a oeo:OEO_00050016 ;
+    oeo:OEO_00140178 "500.0"^^xsd:float ;
+    oeo:OEO_00040010 oeo:OEO_00050008 ;
+    oeo:OEO_00000523 oeo:OEO_00000292 ;
+    oeo:OEO_00000505 oeo:OEO_00000214 ;
+    oeo:OEO_00020440 "2030"^^xsd:integer ;
+    oeo:OEO_00390023 oeo:OEO_00140070 ;
+    rdfs:seeAlso <https://example.org/some-pdf-page-42> .

--- a/mhpkg/schema/examples/kassel_valid.ttl
+++ b/mhpkg/schema/examples/kassel_valid.ttl
@@ -1,0 +1,95 @@
+# A conformant MHPKG instance: Kassel's 2024 municipal heat plan, one target-scenario indicator.
+#
+# Hand-written, with every IRI produced by `python mhpkg/schema/mint_slice.py` rather than typed —
+# a hand-typed UUID is a hand-typed UUID whatever the policy says.
+#
+# Validate with:
+#   .venv/bin/pyshacl -s mhpkg/schema/generated/mhpkg_target_scenario.shacl.ttl \
+#                     -s mhpkg/schema/mhpkg_iri_policy.shacl.ttl \
+#                     -df turtle -f human mhpkg/schema/examples/kassel_valid.ttl
+#
+# ⚠️ THE DATA IS ILLUSTRATIVE, NOT REAL. 241 MWh comes from the Termboard sketch and is far too
+# small for a city of 200,000 — a real Kassel figure would be in the millions of MWh. It is kept
+# because this slice tests the SHAPE, and changing the number would quietly imply the figure had
+# been sourced. No published heat plan has been read yet.
+
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix obo:   <http://purl.obolibrary.org/obo/> .
+@prefix mhpo:  <https://purl.org/mhpo/ontology/> .
+@prefix oeo:   <https://openenergyplatform.org/ontology/oeo/> .
+@prefix mhpkg: <https://openenergyplatform.org/id/mhpkg/> .
+
+# --- The plan -------------------------------------------------------------------------
+# Tier 2: AGS plus the full publication date. That date is not free metadata — it is half the
+# plan's identity, which is why the shapes require it exactly once.
+
+<https://openenergyplatform.org/id/mhpkg/heatplan/AGS_06611000_2024-03-15>
+    a mhpo:MHPO_00020003 ;                                    # municipal heat plan
+    rdfs:label "Kommunale Wärmeplanung Kassel 2024" ;
+    oeo:OEO_00390096 "2024-03-15"^^xsd:date ;                 # has publication date
+    obo:BFO_0000051 <https://openenergyplatform.org/id/mhpkg/targetscenario/AGS_06611000_2024-03-15> ;   # has part
+    oeo:OEO_00000510 <https://openenergyplatform.org/id/mhpkg/organisation/2d4f4ae8-ea0f-575c-9a76-8dcf377042af> .  # has organisation
+
+# --- The target scenario --------------------------------------------------------------
+# Zielszenario, WPG Annex 2 III. MHPO asserts that a municipal heat plan has one as a part, so
+# the `has part` edge above restates an axiom the ontology already holds.
+
+<https://openenergyplatform.org/id/mhpkg/targetscenario/AGS_06611000_2024-03-15>
+    a mhpo:MHPO_00020007 ;                                    # target scenario
+    rdfs:label "Zielszenario Kassel 2024" ;
+    oeo:OEO_00140002 <https://openenergyplatform.org/id/mhpkg/value/a878a3a1-b856-5aaf-b767-d1b4154d11aa> .   # has quantity value
+
+# --- The indicator value --------------------------------------------------------------
+# Tier 3: UUIDv5 over the value's COORDINATES — plan, indicator, carrier, year, aggregation —
+# and never over its magnitude. Correcting 241 to 2410 updates this node; it does not mint a
+# second one and orphan the first.
+
+<https://openenergyplatform.org/id/mhpkg/value/a878a3a1-b856-5aaf-b767-d1b4154d11aa>
+    a oeo:OEO_00050016 ;                                      # final energy consumption value
+    oeo:OEO_00140178 "241.0"^^xsd:float ;                     # has number
+    oeo:OEO_00040010 oeo:OEO_00050008 ;                       # has unit -> megawatt-hour
+    oeo:OEO_00000523 oeo:OEO_00000292 ;                       # covers energy carrier -> natural gas
+    oeo:OEO_00000505 oeo:OEO_00000214 ;                       # covers sector -> household sector
+    oeo:OEO_00020440 "2030"^^xsd:integer ;                    # has scenario year value
+    oeo:OEO_00390023 oeo:OEO_00140070 .                       # has aggregation type -> integral
+
+# --- The contracted planner -----------------------------------------------------------
+# Tier 3 over the NORMALISED label: NFC, casefold, punctuation to space, collapse, strip trailing
+# legal form. `Kassel Wärme Ingenieurbüro`, `  kassel   wärme  ingenieurbüro  ` and
+# `Kassel Wärme Ingenieurbüro GmbH` all mint this same IRI. `Kassel Warme Ingenieurburo` does not.
+
+<https://openenergyplatform.org/id/mhpkg/organisation/2d4f4ae8-ea0f-575c-9a76-8dcf377042af>
+    a oeo:OEO_00030022 ;                                      # organisation
+    rdfs:label "Kassel Wärme Ingenieurbüro" .
+
+# --- The municipality area ------------------------------------------------------------
+#
+# 🔴 PRESENT BUT UNREACHABLE, and this is a finding rather than an oversight in the example.
+#
+# No term in MHPO or OEO relates a PLAN to the area it plans. MHPO has `municipality area` and
+# `heat plan area` and relates areas to one another with BFO `part of`, but nothing connects the
+# plan to either. So this node is a floating island: the plan above cannot say where it applies,
+# which for a municipal heat plan is not a detail. See TERM REQUEST 1 in the schema.
+#
+# ⚠️ AND A SECOND, SHARPER PROBLEM THE SHAPES CAUGHT.
+#
+# The IRI policy §6 rules that `Stadt Kassel, der Bürgermeister` is not a second entity — it is
+# the municipality in a role, and it reuses `municipality/AGS_06611000`. But the only class
+# available for that IRI is `municipality area`, a two-dimensional spatial region. A region cannot
+# commission a plan, and there is no class anywhere in MHPO or OEO for the municipality as a legal
+# body: `Stadt Kassel` the corporation and `Gemeindegebiet Kassel` the territory are different
+# things and only the territory has a term.
+#
+# The IRI shapes make the collision concrete rather than arguable: `MunicipalityAreaIri` requires
+# `.../municipality/AGS_<8 digits>` and `OrganisationIri` requires `.../organisation/<UUIDv5>`, so
+# ONE IRI CANNOT SATISFY BOTH. Typing `municipality/AGS_06611000` as an organisation to make it
+# the commissioning body is therefore not a workaround — it is a validation failure. Which means
+# the planning authority is absent from this example, and WPG §12 makes it a statutory party.
+#
+# Recorded, not patched. It is a conflict between two already-made decisions and belongs to a
+# human, not to this prototype.
+
+<https://openenergyplatform.org/id/mhpkg/municipality/AGS_06611000>
+    a mhpo:MHPO_00020017 ;                                    # municipality area
+    rdfs:label "Gemeindegebiet Kassel" .

--- a/mhpkg/schema/generated/mhpkg_target_scenario.shacl.ttl
+++ b/mhpkg/schema/generated/mhpkg_target_scenario.shacl.ttl
@@ -1,0 +1,169 @@
+@prefix mhpkg_schema: <https://openenergyplatform.org/schema/mhpkg/> .
+@prefix mhpo: <https://purl.org/mhpo/ontology/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix oeo: <https://openenergyplatform.org/ontology/oeo/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+mhpo:MHPO_00020003 a sh:NodeShape ;
+    rdfs:comment """A municipal heat plan — Kommunale Wärmeplanung, WPG §23. MHPO puts it under CCO `plan specification` and asserts that it has as parts an aggregated inventory analysis, an aggregated potential analysis, a target scenario, an implementation measure and an implementation strategy.
+This slice models only the target scenario part. The other four are out of the ticket, not out of the model.""" ;
+    sh:closed true ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:date ;
+            sh:description """The plan's publication date. This is not free metadata — the IRI policy makes it the Tier-2 discriminator, so it is part of the plan's identity and a shape that lets it drift lets the IRI drift with it.
+NEAR MISS — OEO declares domain `report` (obo:IAO_0000088) and range `xsd:dateTime`. MHPO puts `municipal heat plan` under CCO `plan specification`, not under `report`, and a date is not a dateTime. Closer than the three above, but still borrowed.""" ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path oeo:OEO_00390096 ],
+        [ sh:class oeo:OEO_00030022 ;
+            sh:description """OEO `has organisation` — "a relation that holds between an information content entity and the organisation in which it was created". Domain fits: MHPO's `municipal heat plan` is an information content entity by way of CCO.
+Its declared range is not `organisation` but `has role some organisation role`, i.e. OEO reifies the organisation's involvement into a role. This slot deliberately points at the organisation directly and does not model the role, because which role a body plays — commissioning authority versus contracted planner — has no term yet. See TERM REQUEST 3.""" ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path oeo:OEO_00000510 ],
+        [ sh:description "The instance IRI, minted by the three-tier pure function of the IRI policy." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path mhpkg_schema:id ],
+        [ sh:datatype xsd:string ;
+            sh:description "The human-readable name, in German. Umlauts live here and never in an IRI — the IRI policy keeps identity ASCII-only and puts the German in the label, where it is unambiguous and universally supported." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdfs:label ],
+        [ sh:class mhpo:MHPO_00020007 ;
+            sh:description "BFO `has part`. MHPO declares this object property and already asserts `municipal heat plan SubClassOf has part some target scenario`, so this slot restates an axiom the ontology holds rather than inventing a relation." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path obo:BFO_0000051 ] ;
+    sh:targetClass mhpo:MHPO_00020003 .
+
+mhpo:MHPO_00020017 a sh:NodeShape ;
+    rdfs:comment """A municipality area — Gemeindegebiet. MHPO puts it under OEO `region` and gives it a `municipality area role`.
+Present in the slice but UNREACHABLE from the plan: no cited term relates a plan to the area it plans. See TERM REQUEST 1. Its AGS is carried by its IRI.""" ;
+    sh:closed true ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "The human-readable name, in German. Umlauts live here and never in an IRI — the IRI policy keeps identity ASCII-only and puts the German in the label, where it is unambiguous and universally supported." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdfs:label ],
+        [ sh:description "The instance IRI, minted by the three-tier pure function of the IRI policy." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path mhpkg_schema:id ] ;
+    sh:targetClass mhpo:MHPO_00020017 .
+
+oeo:OEO_00030022 a sh:NodeShape ;
+    rdfs:comment """An organisation. Used for both the planning authority and the contracted planner, because no term distinguishes the two roles — see TERM REQUEST 3.
+A municipality acting as planning authority is NOT a second entity: `Stadt Kassel, der Bürgermeister` is the municipality in a role, and the IRI policy gives it the Tier-1 municipality IRI. Only bodies with no register key are minted here.""" ;
+    sh:closed true ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "The human-readable name, in German. Umlauts live here and never in an IRI — the IRI policy keeps identity ASCII-only and puts the German in the label, where it is unambiguous and universally supported." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdfs:label ],
+        [ sh:description "The instance IRI, minted by the three-tier pure function of the IRI policy." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path mhpkg_schema:id ] ;
+    sh:targetClass oeo:OEO_00030022 .
+
+oeo:OEO_00050016 a sh:NodeShape ;
+    rdfs:comment """A final energy consumption value — Endenergieverbrauch. OEO defines it as an energy consumption value about energy delivered to and consumed by end users, and it is exactly indicator 1 of WPG Annex 2 III.
+Its identity is its coordinates and not its magnitude: the same plan, indicator, carrier, year and aggregation always mint the same IRI, so a corrected figure updates this node.""" ;
+    sh:closed true ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:description """OEO `covers energy carrier`.
+MISMATCH — its declared domain is `study` (oeo:OEO_00020011), and the subject here is a consumption value, not a study. OWL domains are inferential rather than constraining, so a reasoner will not complain; it will silently infer that every MHPKG consumption value IS a study. SHACL cannot see this at all. Recorded as a term request rather than worked around.""" ;
+            sh:in ( oeo:OEO_00000292 oeo:OEO_00000211 oeo:OEO_00000220 oeo:OEO_00010214 oeo:OEO_00020050 ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:order 3 ;
+            sh:path oeo:OEO_00000523 ],
+        [ sh:description "OEO `has unit`, domain `quantity value`, range `unit`. Exact fit." ;
+            sh:in ( oeo:OEO_00050008 obo:UO_0000224 oeo:OEO_00050011 ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:order 2 ;
+            sh:path oeo:OEO_00040010 ],
+        [ sh:datatype xsd:integer ;
+            sh:description """The target year the value is stated for. WPG Annex 2 III requires the indicators for 2030, 2035, 2040 and 2045 unless otherwise specified.
+MISMATCH, and the worst of the three — OEO `has scenario year value` declares domain `scenario factsheet` (oeo:OEO_00000365) AND range `xsd:dateTime`. This slot uses it on a consumption value with an `xsd:integer`, so both ends are wrong. A year is a temporal region, and BFO has `one-dimensional temporal region`; what is missing is a relation from a value to it.""" ;
+            sh:maxCount 1 ;
+            sh:maxInclusive 2100 ;
+            sh:minCount 1 ;
+            sh:minInclusive 2024 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path oeo:OEO_00020440 ],
+        [ sh:description "The instance IRI, minted by the three-tier pure function of the IRI policy." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path mhpkg_schema:id ],
+        [ sh:datatype xsd:float ;
+            sh:description "A consumption cannot be negative. This is the one constraint in the whole slice that comes from the domain rather than from a term — and it is exactly the kind of thing the rejected \"generate SHACL from MHPO\" route could never have produced, because OWL is open-world and carries no such assertion." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:minInclusive 0 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path oeo:OEO_00140178 ],
+        [ sh:description "OEO `covers sector`. Same mismatch as `covers_energy_carrier` — declared domain `study`. WPG Annex 2 III.1 requires the final energy consumption differentiated by final energy sector, so the slot is unavoidable; only the relation is borrowed." ;
+            sh:in ( oeo:OEO_00000214 oeo:OEO_00000227 oeo:OEO_00000128 ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:order 4 ;
+            sh:path oeo:OEO_00000505 ],
+        [ sh:description "OEO `has aggregation type`. Declares no domain, so no unintended inference." ;
+            sh:in ( oeo:OEO_00140070 oeo:OEO_00140071 oeo:OEO_00140069 oeo:OEO_00140072 oeo:OEO_00140073 ) ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:order 6 ;
+            sh:path oeo:OEO_00390023 ] ;
+    sh:targetClass oeo:OEO_00050016 .
+
+mhpo:MHPO_00020007 a sh:NodeShape ;
+    rdfs:comment "The target scenario — Zielszenario, WPG Annex 2 III. An objective specification that uses indicators to describe how a heat supply from renewable energy or unavoidable waste heat is to be achieved." ;
+    sh:closed true ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "The human-readable name, in German. Umlauts live here and never in an IRI — the IRI policy keeps identity ASCII-only and puts the German in the label, where it is unambiguous and universally supported." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdfs:label ],
+        [ sh:class oeo:OEO_00050016 ;
+            sh:description """OEO `has quantity value` — "a relation between an entity and a quantity value". Declares no domain, so using it on a target scenario adds no unintended inference.
+Note that MHPO asserts nothing here. Its `target scenario` definition says the scenario "uses indicators to describe" the goal, and its comment enumerates the seven WPG Annex 2 III indicators, but no axiom connects a scenario to a value. This slot is the first place the data shape goes beyond what the T-Box states.""" ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path oeo:OEO_00140002 ],
+        [ sh:description "The instance IRI, minted by the three-tier pure function of the IRI policy." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path mhpkg_schema:id ] ;
+    sh:targetClass mhpo:MHPO_00020007 .
+
+

--- a/mhpkg/schema/mhpkg_iri_policy.shacl.ttl
+++ b/mhpkg/schema/mhpkg_iri_policy.shacl.ttl
@@ -1,0 +1,115 @@
+# The IRI and namespace policy, as enforceable shapes.
+#
+# HAND-WRITTEN, AND THAT IS THE POINT. Everything in `generated/` comes out of
+# `mhpkg_target_scenario.yaml` via `gen-shacl`. This file cannot, and the reason is structural
+# rather than a version bug:
+#
+#   SHACL constrains a focus node's OWN IRI with `sh:pattern` at NODE level. LinkML has no way to
+#   emit that. Its `identifier: true` slot becomes an ordinary property shape on an invented
+#   property (`mhpkg_schema:id`), which appears in no instance triple, so a pattern attached there
+#   is well-formed and can never fire. A type-level `pattern` is dropped outright — silently when
+#   the type has a `uri:`, and with a logged ERROR and EXIT CODE 0 when it does not.
+#
+# So the machine-checkable half of the IRI policy that MH-02 delegated to the LinkML schema lives
+# here instead. This is the first artifact in this repository that must be hand-maintained
+# alongside generated output, which makes it direct input to MH-07: the generated-artifacts
+# contract cannot say "everything is generated".
+#
+# WHAT THIS FILE IS FOR, precisely: identity. The generated shapes check that a heat plan has a
+# label, one publication date and a target scenario. Nothing in them checks that the plan's IRI is
+# the one the policy says it must be — and since the policy's whole purpose is that a re-run mints
+# byte-identical IRIs, an unchecked IRI is an unchecked re-runnability guarantee.
+#
+# Verified to reject, not merely to accept — see `examples/kassel_invalid.ttl`:
+#   * a missing leading zero (`AGS_6611000`), where the leading zero is significant
+#   * an umlaut-stripped organisation hash, the Termboard defect meeting this policy
+#   * a UUIDv4 where the policy requires v5, i.e. random where it requires reproducible
+
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix mhpo:  <https://purl.org/mhpo/ontology/> .
+@prefix oeo:   <https://openenergyplatform.org/ontology/oeo/> .
+@prefix mhpkg_shapes: <https://openenergyplatform.org/schema/mhpkg/shapes/> .
+
+# --- Tier 1: official public register key ---------------------------------------------
+#
+# `AGS_` names the register — the Amtlicher Gemeindeschlüssel, 8 digits. Register-qualified
+# because Germany's keys are all bare digits and otherwise indistinguishable, and because it
+# makes the leading zero's significance visible: `6611000` is a DIFFERENT municipality IRI, and
+# this shape is what turns that from a convention into a rejection.
+
+mhpkg_shapes:MunicipalityAreaIri
+    a sh:NodeShape ;
+    sh:targetClass mhpo:MHPO_00020017 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://openenergyplatform\\.org/id/mhpkg/municipality/AGS_[0-9]{8}$" ;
+    sh:message "Tier-1 violation: a municipality area IRI must be https://openenergyplatform.org/id/mhpkg/municipality/AGS_ plus exactly 8 digits. The leading zero is significant." .
+
+# --- Tier 2: register key plus a discriminator ----------------------------------------
+#
+# The discriminator is the plan's FULL ISO-8601 publication date, not the year: WPG §25(1)
+# obliges a review at least every five years, and a draft plus a final in one year would collide
+# under a year-only key.
+
+mhpkg_shapes:MunicipalHeatPlanIri
+    a sh:NodeShape ;
+    sh:targetClass mhpo:MHPO_00020003 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://openenergyplatform\\.org/id/mhpkg/heatplan/AGS_[0-9]{8}_[0-9]{4}-[0-9]{2}-[0-9]{2}$" ;
+    sh:message "Tier-2 violation: a heat plan IRI must be .../heatplan/AGS_<8 digits>_<YYYY-MM-DD>. The full publication date is required, not the year alone." .
+
+mhpkg_shapes:TargetScenarioIri
+    a sh:NodeShape ;
+    sh:targetClass mhpo:MHPO_00020007 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://openenergyplatform\\.org/id/mhpkg/targetscenario/AGS_[0-9]{8}_[0-9]{4}-[0-9]{2}-[0-9]{2}$" ;
+    sh:message "Tier-2 violation: a target scenario IRI must be .../targetscenario/AGS_<8 digits>_<YYYY-MM-DD>, discriminated by the heat plan it belongs to." .
+
+# --- Tier 3: UUIDv5 over the identifying tuple ----------------------------------------
+#
+# The version nibble is pinned to `5` and the variant nibble to [89ab]. This is not cosmetic:
+# UUIDv5 is a namespace+name hash and is deterministic, v4 is random. A v4 here would break the
+# governing constraint that minting is a pure function of the data, and it is exactly the defect
+# MH-02 found in the OEKG — all 388 of its instance ids are random hex wearing UUID dashes, with
+# the version nibble uniformly spread over all 16 values instead of pinned to `4`.
+#
+# Lower case is required too. Hex is case-insensitive as a number but IRIs are not, so `A` and `a`
+# would be two identities for one thing.
+
+mhpkg_shapes:ConsumptionValueIri
+    a sh:NodeShape ;
+    sh:targetClass oeo:OEO_00050016 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://openenergyplatform\\.org/id/mhpkg/value/[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" ;
+    sh:message "Tier-3 violation: a value IRI must be .../value/<lower-case UUIDv5>. Version nibble 5, not 4 — a random id would break re-runnability." .
+
+mhpkg_shapes:OrganisationIri
+    a sh:NodeShape ;
+    sh:targetClass oeo:OEO_00030022 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://openenergyplatform\\.org/id/mhpkg/organisation/[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" ;
+    sh:message "Tier-3 violation: an organisation IRI must be .../organisation/<lower-case UUIDv5> over the normalised label." .
+
+# --- The umlaut rule ------------------------------------------------------------------
+#
+# Umlauts never reach an IRI: Tier 1 is digits and Tier 3 is hex, so the patterns above already
+# exclude them. German text lives in `rdfs:label`, and this shape guards the other direction —
+# that no MHPKG instance IRI anywhere carries a non-ASCII or percent-encoded character.
+#
+# MHPKG would otherwise be the first non-ASCII IRI in this family; there are currently zero
+# non-ASCII and zero percent-encoded IRIs anywhere in the `oekg` repository.
+#
+# ⚠️ WHAT THIS CANNOT CATCH, stated rather than implied. The policy's real umlaut exposure is on
+# the HASH INPUT, not the output: `Kassel Wärme Ingenieurbüro` and `Kassel Warme Ingenieurburo`
+# both normalise cleanly and both mint a valid-looking Tier-3 IRI — two different organisations,
+# silently, with no error. That is precisely the Termboard defect, and no shape can see it,
+# because both outputs are well-formed. It is caught only by never machine-consuming
+# umlaut-stripping output, which is why that is a standing decision rather than a validation rule.
+
+mhpkg_shapes:NoNonAsciiInstanceIri
+    a sh:NodeShape ;
+    sh:targetClass mhpo:MHPO_00020003, mhpo:MHPO_00020007, mhpo:MHPO_00020017,
+                   oeo:OEO_00050016, oeo:OEO_00030022 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^[\\u0021-\\u007E]*$" ;
+    sh:message "An MHPKG instance IRI must be pure printable ASCII with no percent-encoding. German belongs in rdfs:label." .

--- a/mhpkg/schema/mhpkg_target_scenario.yaml
+++ b/mhpkg/schema/mhpkg_target_scenario.yaml
@@ -1,0 +1,507 @@
+id: https://openenergyplatform.org/schema/mhpkg/target-scenario
+name: mhpkg_target_scenario
+title: MHPKG — municipal heat plan and one target-scenario indicator
+description: >-
+  First cut of the MHPKG data shape, covering one slice of the domain: a municipal heat plan,
+  the target scenario it contains, and one final energy consumption value inside that scenario.
+
+  This schema AUTHORS THE DATA SHAPE ONLY. It mints no domain terms. Every class carries a
+  `class_uri` and every slot a `slot_uri` pointing at a term that MHPO or OEO already declares,
+  and `gen-owl` is never run against it — MHPO owns the OWL rendering of this domain.
+
+  Slots that the domain needs but no cited ontology provides are NOT invented here. They appear
+  as commented-out blocks marked TERM REQUEST, so the hole is visible in the artifact rather
+  than hidden in a document. See `README.md` for the list and `../mhpo/terms.csv` for what may
+  be cited at the current pin.
+
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+prefixes:
+  # --- MHPKG's own namespaces. Fixed by the IRI and namespace policy (MH-02). ---
+  # `mhpkg` names THINGS; `mhpkg_graph` names SETS OF STATEMENTS about them. Instance data
+  # never appears under a `/ontology/` path — an individual is not an ontology term.
+  mhpkg: https://openenergyplatform.org/id/mhpkg/
+  mhpkg_graph: https://openenergyplatform.org/graph/mhpkg/
+  mhpkg_schema: https://openenergyplatform.org/schema/mhpkg/
+
+  # --- The T-Box. Nothing below this line is defined by this repository. ---
+  mhpo: https://purl.org/mhpo/ontology/
+  oeo: https://openenergyplatform.org/ontology/oeo/
+  obo: http://purl.obolibrary.org/obo/
+  cco: https://www.commoncoreontologies.org/
+
+  # --- Infrastructure vocabulary. Not domain terms; carries no modelling commitment. ---
+  linkml: https://w3id.org/linkml/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  xsd: http://www.w3.org/2001/XMLSchema#
+
+default_prefix: mhpkg_schema
+default_range: string
+default_curi_maps:
+  - semweb_context
+
+imports:
+  - linkml:types
+
+# The MHPO commit these MHPO_* IRIs were checked against. Mirrors `../mhpo/pin.txt`; MHPO has no
+# releases and no tags, so a commit SHA is the only pin available.
+source: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/tree/34776b699d10c936da05b353b1001548bf92e4b2
+
+# =====================================================================================
+# Types — deliberately absent, and this is a finding rather than an omission
+# =====================================================================================
+#
+# The first draft of this schema declared five `uriorcurie` types, one per IRI tier, each
+# carrying the IRI-policy regex as a type-level `pattern`. That is the natural LinkML way to
+# express "instance IRIs look like this", and it is the machine-readable half of the IRI policy
+# that MH-02 explicitly delegated here.
+#
+# It does not survive `gen-shacl` (linkml 1.11.1). Measured:
+#
+#   * a type-level `pattern` is DROPPED — no `sh:pattern` is emitted, and with `uri:` set there
+#     is no diagnostic at all. Without `uri:` there is one, `ERROR: No URI for type X` — logged,
+#     and the process still EXITS 0. Same class of trap as `uv sync --frozen` in MH-04: a check
+#     that reports failure through a channel nobody reads.
+#   * a slot-level `pattern` IS emitted, for both `uriorcurie` and `string` ranges.
+#   * on the `identifier` slot, a slot-level pattern is emitted — but attached to `sh:path
+#     mhpkg_schema:id`, an invented property that appears in no instance triple. The constraint
+#     is well-formed and can never fire.
+#
+# So the IRI policy is NOT expressible through this generator: SHACL constrains a focus node's
+# own IRI with `sh:pattern` at NODE level, and LinkML has no way to emit that. The policy is
+# enforced instead by a hand-written companion file, `mhpkg_iri_policy.shacl.ttl`, which is
+# verified to reject both a missing leading zero and an umlaut-stripped name.
+#
+# That companion file is the first thing in this repository that must be hand-written alongside
+# generated output, so it is direct input to MH-07: the generated-artifacts contract cannot say
+# "everything is generated".
+
+# =====================================================================================
+# Slots
+# =====================================================================================
+#
+# Every slot_uri below is a term MHPO or OEO already declares. Where the declared domain of a
+# term does not match the subject it is used on here, that is called out on the slot — those
+# are the mismatches this prototype exists to surface, not defects to paper over.
+
+slots:
+  # --- Identity ---------------------------------------------------------------------
+
+  id:
+    identifier: true
+    range: uriorcurie
+    description: The instance IRI, minted by the three-tier pure function of the IRI policy.
+
+  # --- Labels -----------------------------------------------------------------------
+
+  label:
+    slot_uri: rdfs:label
+    range: string
+    required: true
+    description: >-
+      The human-readable name, in German. Umlauts live here and never in an IRI — the IRI
+      policy keeps identity ASCII-only and puts the German in the label, where it is
+      unambiguous and universally supported.
+
+  # --- Structure of the plan --------------------------------------------------------
+
+  has_part:
+    slot_uri: obo:BFO_0000051
+    description: >-
+      BFO `has part`. MHPO declares this object property and already asserts
+      `municipal heat plan SubClassOf has part some target scenario`, so this slot restates an
+      axiom the ontology holds rather than inventing a relation.
+
+  has_quantity_value:
+    slot_uri: oeo:OEO_00140002
+    description: >-
+      OEO `has quantity value` — "a relation between an entity and a quantity value". Declares no
+      domain, so using it on a target scenario adds no unintended inference.
+
+      Note that MHPO asserts nothing here. Its `target scenario` definition says the scenario
+      "uses indicators to describe" the goal, and its comment enumerates the seven WPG Annex 2 III
+      indicators, but no axiom connects a scenario to a value. This slot is the first place the
+      data shape goes beyond what the T-Box states.
+
+  # --- The quantity value pattern ---------------------------------------------------
+  #
+  # OEO's `quantity value` is itself a reification: the number and the unit hang off a value node
+  # rather than off the thing measured. That is the same move LinkML would make anyway, which is
+  # why this half of the slice maps cleanly.
+
+  has_number:
+    slot_uri: oeo:OEO_00140178
+    range: float
+    required: true
+    description: >-
+      OEO `has number`, a datatype property whose declared domain is `quantity value`. Exact fit.
+
+  has_unit:
+    slot_uri: oeo:OEO_00040010
+    range: EnergyUnitEnum
+    required: true
+    description: >-
+      OEO `has unit`, domain `quantity value`, range `unit`. Exact fit.
+
+  covers_energy_carrier:
+    slot_uri: oeo:OEO_00000523
+    range: EnergyCarrierEnum
+    required: true
+    description: >-
+      OEO `covers energy carrier`.
+
+      MISMATCH — its declared domain is `study` (oeo:OEO_00020011), and the subject here is a
+      consumption value, not a study. OWL domains are inferential rather than constraining, so a
+      reasoner will not complain; it will silently infer that every MHPKG consumption value IS a
+      study. SHACL cannot see this at all. Recorded as a term request rather than worked around.
+
+  covers_sector:
+    slot_uri: oeo:OEO_00000505
+    range: SectorEnum
+    required: true
+    description: >-
+      OEO `covers sector`. Same mismatch as `covers_energy_carrier` — declared domain `study`.
+      WPG Annex 2 III.1 requires the final energy consumption differentiated by final energy
+      sector, so the slot is unavoidable; only the relation is borrowed.
+
+  has_scenario_year_value:
+    slot_uri: oeo:OEO_00020440
+    range: integer
+    required: true
+    minimum_value: 2024
+    maximum_value: 2100
+    description: >-
+      The target year the value is stated for. WPG Annex 2 III requires the indicators for 2030,
+      2035, 2040 and 2045 unless otherwise specified.
+
+      MISMATCH, and the worst of the three — OEO `has scenario year value` declares domain
+      `scenario factsheet` (oeo:OEO_00000365) AND range `xsd:dateTime`. This slot uses it on a
+      consumption value with an `xsd:integer`, so both ends are wrong. A year is a temporal
+      region, and BFO has `one-dimensional temporal region`; what is missing is a relation from a
+      value to it.
+
+  has_aggregation_type:
+    slot_uri: oeo:OEO_00390023
+    range: AggregationTypeEnum
+    required: true
+    description: >-
+      OEO `has aggregation type`. Declares no domain, so no unintended inference.
+
+  # --- Provenance and the publishing body -------------------------------------------
+
+  has_publication_date:
+    slot_uri: oeo:OEO_00390096
+    range: date
+    required: true
+    description: >-
+      The plan's publication date. This is not free metadata — the IRI policy makes it the Tier-2
+      discriminator, so it is part of the plan's identity and a shape that lets it drift lets the
+      IRI drift with it.
+
+      NEAR MISS — OEO declares domain `report` (obo:IAO_0000088) and range `xsd:dateTime`. MHPO
+      puts `municipal heat plan` under CCO `plan specification`, not under `report`, and a date is
+      not a dateTime. Closer than the three above, but still borrowed.
+
+  has_organisation:
+    slot_uri: oeo:OEO_00000510
+    description: >-
+      OEO `has organisation` — "a relation that holds between an information content entity and
+      the organisation in which it was created". Domain fits: MHPO's `municipal heat plan` is an
+      information content entity by way of CCO.
+
+      Its declared range is not `organisation` but `has role some organisation role`, i.e. OEO
+      reifies the organisation's involvement into a role. This slot deliberately points at the
+      organisation directly and does not model the role, because which role a body plays —
+      commissioning authority versus contracted planner — has no term yet. See TERM REQUEST 3.
+
+# =====================================================================================
+# TERM REQUESTS — slots this slice needs and no cited ontology provides
+# =====================================================================================
+#
+# Left commented out on purpose. The guardrail is that LinkML never mints a domain term, so a
+# missing term is an MHPO term request and not a new LinkML element. Writing them here, in the
+# position they would occupy, keeps the hole visible in the artifact.
+#
+#   1. WHICH AREA A PLAN IS FOR.
+#      MHPO has `municipality area` (MHPO_00020017) and `heat plan area` (MHPO_00020018), and
+#      relates areas to each other with BFO `part of`. Nothing relates a *plan* to the area it
+#      plans. Without it a heat plan cannot say where it applies.
+#
+#      # plans_area:
+#      #   slot_uri: mhpo:MHPO_TBD
+#      #   range: MunicipalityArea
+#      #   required: true
+#
+#   2. THE AGS OF A MUNICIPALITY AREA, AS DATA.
+#      The IRI carries it — Tier 1 is `municipality/AGS_06611000` — so it is recoverable by
+#      string surgery on the identifier, which is why this prototype does not block on it. But a
+#      key that exists only inside an IRI cannot be queried, typed or constrained as a key.
+#      OEO's `unique individual identifier` (OEO_00010037) is an ANNOTATION property, so it is
+#      not usable as a data slot.
+#
+#      # ags:
+#      #   slot_uri: mhpo:MHPO_TBD
+#      #   range: string
+#      #   pattern: '^\d{8}$'
+#
+#   3. THE ROLE A BODY PLAYS TOWARDS A PLAN.
+#      The slice has two organisations doing two different things: Stadt Kassel commissions the
+#      plan as the planning authority, and an engineering office produces it. `has_organisation`
+#      collapses them into one relation. OEO has `organisation role` (OEO_00000315) as a parent,
+#      but no `planning authority role` or `contracted planner role`, and WPG §12 makes the
+#      planning authority a statutory party — this is a real distinction, not a nicety.
+#
+#   4. A RELATION FROM A VALUE TO A TEMPORAL REGION, AND TO AN ENERGY CARRIER AND SECTOR.
+#      Covered above as mismatches rather than gaps, because a borrowable term exists. They
+#      belong on the same term request: what is wanted is `covers energy carrier` / `covers
+#      sector` with domains widened past `study`, or sibling relations for quantity values.
+
+# =====================================================================================
+# Enums — the controlled vocabularies, every value an OEO term
+# =====================================================================================
+#
+# This is the best result of the prototype and the pattern the rest of the schema should follow.
+#
+# THE PROBLEM these solve. OEO models units, energy carriers and sectors as CLASSES, not as
+# individuals — `natural gas` (OEO_00000292) is a class of material entity, whose instances are
+# particular parcels of gas. But an aggregate heat-plan statistic is about the carrier TYPE, and
+# there is no parcel of gas to point at. Pointing an instance-level property at a class IRI is
+# punning, and it is unavoidable for statistical data.
+#
+# PRECEDENT, not invention: `oekg/shapes/oekg_shapes.ttl` already does exactly this. Its
+# `covers_energy_carrier` property shape is an `sh:in` enumerating 120-odd OEO class IRIs,
+# `OEO_00000292` among them. So punning is the established pattern in this family and its own
+# shapes bless it. This slice follows it rather than inventing a third way.
+#
+#   (⚠️ Those OEKG shapes are also broken in a way worth knowing about but NOT worth fixing here
+#   — the predecessor map ruled OEKG changes out of scope. They declare the OEO prefix as
+#   `http://openenergy-platform.org/ontology/oeo/` — hyphenated, http — and use readable property
+#   names like `oeo:covers_energy_carrier` that OEO does not define.
+#
+#   Be precise about the namespace, because a reader who checks will find it resolves. It does:
+#   `http://openenergy-platform.org/ontology/oeo/OEO_00050016` returns 200, redirecting to the
+#   un-hyphenated host. But IRIs are IDENTITY, not addresses. OEO's own file declares
+#   `xmlns:oeo="https://openenergyplatform.org/ontology/oeo/"` and mints every term under it, so
+#   the hyphenated string is a DIFFERENT term that merely serves the same web page. Resolving is
+#   not matching, and this is the mechanical reason no SHACL file in this repository validates any
+#   live graph.
+#
+#   `linkml-lint` will warn that this schema's `oeo` prefix is not canonical and should be the
+#   hyphenated http form. That warning is a stale registry entry, not a defect here: the prefix
+#   below is the one OEO actually mints its terms under. The warning is accepted, not silenced.)
+#
+# WHY AN ENUM AND NOT `range: uriorcurie`. A bare `uriorcurie` generates `sh:nodeKind sh:IRI`,
+# which accepts any IRI at all — including a typo, or an MHPO area class where a carrier belongs.
+# An enum whose every `meaning:` is an OEO IRI generates `sh:in`, so the value set is enforced.
+# It mints nothing: the permissible-value keys are local labels for the RAG side's payload, and
+# the IRI is always OEO's.
+#
+# These lists are DELIBERATELY SHORT — the carriers, sectors and units this one slice needs.
+# Completing them is not this ticket's work, and a long list assembled without a heat plan in
+# front of it would be guesswork.
+
+enums:
+  EnergyCarrierEnum:
+    description: >-
+      Energy carriers, per WPG Annex 2 III.1 ("by energy carrier"). All OEO classes; every IRI
+      below was resolved against OEO 2.13.0 and its label read, not guessed.
+
+      🔴 THE MEMBERSHIP OF THIS LIST CANNOT BE CHECKED BY ANY TOOL IN THIS REPOSITORY, and that
+      is the sharpest finding of the prototype after the IRI-policy gap.
+
+      OEO's `energy carrier` (OEO_00020039) has exactly four asserted subclasses, and all four are
+      abstract: renewable, primary, secondary and final energy carrier. `natural gas` is a
+      subclass of `gas mixture`, not of `energy carrier`. It qualifies only through the
+      equivalence axiom `energy carrier ≡ material entity and has disposition some energy carrier
+      disposition` — i.e. BY INFERENCE. The OEKG's own shape file says so out loud: its `sh:in`
+      list is commented "energy carrier subclassed and as inferred".
+
+      So establishing that a candidate IRI really is an energy carrier needs a reasoner. This
+      repository has `pyshacl` and `rdflib`, neither of which reasons, and MH-01 deliberately kept
+      ROBOT, ODK and Docker out of the contributor setup. The list is therefore a hand-curated
+      snapshot that can drift from OEO silently — the same drift problem MH-01 solved for MHPO
+      terms by vendoring a generated list and checking it in CI, recurring one level down. Direct
+      input to MH-07 and MH-12.
+
+      ⚠️ Two IRIs were nearly wrong here and were caught only by resolving them. `OEO_00020196`,
+      which appears in the OEKG's carrier enumeration, is `fissile material entity` — correct
+      there, but not the district heating it might be mistaken for. And `district heating`
+      (OEO_00000132) is NOT an energy carrier at all: OEO puts it under `grid-bound heating`, a
+      transfer process. OEO is right and the intuition was wrong — WPG Annex 2 III.3 asks for the
+      consumption "of district heating BY energy carrier", so district heating is the supply route
+      and the carrier is whatever fuels it. It is deliberately absent below.
+    permissible_values:
+      natural_gas:
+        meaning: oeo:OEO_00000292
+        description: Erdgas.
+      heating_oil:
+        meaning: oeo:OEO_00000211
+        description: Heizöl.
+      hydrogen:
+        meaning: oeo:OEO_00000220
+        description: Wasserstoff.
+      biomass:
+        meaning: oeo:OEO_00010214
+        description: Biomasse.
+      renewable_energy_carrier:
+        meaning: oeo:OEO_00020050
+        description: >-
+          Erneuerbarer Energieträger. A parent rather than a specific carrier, and the one entry
+          here that IS an asserted subclass of `energy carrier`. Present because heat plans
+          routinely report an aggregate renewable share with no breakdown.
+
+  SectorEnum:
+    description: >-
+      Final energy sectors, per WPG Annex 2 III.1 ("by final energy sector"). All OEO classes.
+
+      ⚠️ WPG's sector division is not OEO's. OEO carries several named divisions — German energy
+      balance, Eurostat, CRF — and picking one is a modelling decision this slice does not have
+      the evidence to make. These three are OEO's generic demand sectors, which is the closest
+      honest fit until a real heat plan's sector table has been read.
+    permissible_values:
+      household:
+        meaning: oeo:OEO_00000214
+        description: Haushalte.
+      industry:
+        meaning: oeo:OEO_00000227
+        description: Industrie.
+      energy_demand_sector:
+        meaning: oeo:OEO_00000128
+        description: The parent, for a figure reported without a sector breakdown.
+
+  EnergyUnitEnum:
+    description: >-
+      Units an energy figure may be stated in. WPG Annex 2 III.1 specifies kilowatt-hours per
+      year; MWh and GWh are what heat plans actually print.
+    permissible_values:
+      megawatt_hour:
+        meaning: oeo:OEO_00050008
+        description: MWh.
+      kilowatt_hour:
+        meaning: obo:UO_0000224
+        description: >-
+          kWh — the unit the statute names. Note the namespace: OEO mints MWh and GWh itself but
+          takes kWh from the Units Ontology, so this one enum spans two namespaces. A consumer
+          that assumed all units were `oeo:` would break on the statutory unit.
+      gigawatt_hour:
+        meaning: oeo:OEO_00050011
+        description: GWh.
+
+  AggregationTypeEnum:
+    description: >-
+      OEO's aggregation types. Unlike the three enums above these ARE named individuals in OEO,
+      so this one involves no punning.
+    permissible_values:
+      integral:
+        meaning: oeo:OEO_00140070
+        description: >-
+          What an annual consumption figure is — a quantity summed over the year, not a reading
+          taken at a moment.
+      arithmetic_mean:
+        meaning: oeo:OEO_00140071
+      instantaneous:
+        meaning: oeo:OEO_00140069
+      minimum:
+        meaning: oeo:OEO_00140072
+      maximum:
+        meaning: oeo:OEO_00140073
+
+# =====================================================================================
+# Classes
+# =====================================================================================
+
+classes:
+  MunicipalHeatPlan:
+    class_uri: mhpo:MHPO_00020003
+    description: >-
+      A municipal heat plan — Kommunale Wärmeplanung, WPG §23. MHPO puts it under CCO
+      `plan specification` and asserts that it has as parts an aggregated inventory analysis, an
+      aggregated potential analysis, a target scenario, an implementation measure and an
+      implementation strategy.
+
+      This slice models only the target scenario part. The other four are out of the ticket, not
+      out of the model.
+    slots:
+      - id
+      - label
+      - has_publication_date
+      - has_part
+      - has_organisation
+    slot_usage:
+      has_part:
+        range: TargetScenario
+        required: true
+        multivalued: false
+      has_organisation:
+        range: Organisation
+        required: true
+        multivalued: true
+
+  TargetScenario:
+    class_uri: mhpo:MHPO_00020007
+    description: >-
+      The target scenario — Zielszenario, WPG Annex 2 III. An objective specification that uses
+      indicators to describe how a heat supply from renewable energy or unavoidable waste heat is
+      to be achieved.
+    slots:
+      - id
+      - label
+      - has_quantity_value
+    slot_usage:
+      has_quantity_value:
+        range: FinalEnergyConsumptionValue
+        required: true
+        multivalued: true
+
+  FinalEnergyConsumptionValue:
+    class_uri: oeo:OEO_00050016
+    description: >-
+      A final energy consumption value — Endenergieverbrauch. OEO defines it as an energy
+      consumption value about energy delivered to and consumed by end users, and it is exactly
+      indicator 1 of WPG Annex 2 III.
+
+      Its identity is its coordinates and not its magnitude: the same plan, indicator, carrier,
+      year and aggregation always mint the same IRI, so a corrected figure updates this node.
+    slots:
+      - id
+      - has_number
+      - has_unit
+      - covers_energy_carrier
+      - covers_sector
+      - has_scenario_year_value
+      - has_aggregation_type
+    slot_usage:
+      has_number:
+        minimum_value: 0
+        description: >-
+          A consumption cannot be negative. This is the one constraint in the whole slice that
+          comes from the domain rather than from a term — and it is exactly the kind of thing the
+          rejected "generate SHACL from MHPO" route could never have produced, because OWL is
+          open-world and carries no such assertion.
+
+  MunicipalityArea:
+    class_uri: mhpo:MHPO_00020017
+    description: >-
+      A municipality area — Gemeindegebiet. MHPO puts it under OEO `region` and gives it a
+      `municipality area role`.
+
+      Present in the slice but UNREACHABLE from the plan: no cited term relates a plan to the area
+      it plans. See TERM REQUEST 1. Its AGS is carried by its IRI.
+    slots:
+      - id
+      - label
+    slot_usage:
+
+  Organisation:
+    class_uri: oeo:OEO_00030022
+    description: >-
+      An organisation. Used for both the planning authority and the contracted planner, because
+      no term distinguishes the two roles — see TERM REQUEST 3.
+
+      A municipality acting as planning authority is NOT a second entity: `Stadt Kassel, der
+      Bürgermeister` is the municipality in a role, and the IRI policy gives it the Tier-1
+      municipality IRI. Only bodies with no register key are minted here.
+    slots:
+      - id
+      - label
+    slot_usage:

--- a/mhpkg/schema/mint_slice.py
+++ b/mhpkg/schema/mint_slice.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Mint the instance IRIs used by this slice's example data.
+
+The IRI policy (MH-02) is a PURE FUNCTION of the data: two independent runs over the same heat
+plan must produce byte-identical IRIs. This script is how the example instances get their IRIs,
+so that `examples/kassel_valid.ttl` can be regenerated rather than hand-maintained — a hand-typed
+UUID is a hand-typed UUID whatever the policy says.
+
+Deliberately stdlib-only, and deliberately a copy of the policy's own `mint.py` rather than an
+import of it: `pyproject.toml` sets `package = false`, so there is nothing here to import from.
+That duplication is a known, recorded limit of the policy, not an oversight.
+
+Usage:
+    python mhpkg/schema/mint_slice.py
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+import uuid
+
+BASE = "https://openenergyplatform.org/id/mhpkg/"
+GRAPH = "https://openenergyplatform.org/graph/mhpkg/"
+
+# Namespace UUIDs are DERIVED, not magic constants: anyone can recompute them.
+NS_MHPKG = uuid.uuid5(uuid.NAMESPACE_URL, BASE)
+
+LEGAL = r"(gmbh\s*&\s*co\.?\s*kg|gmbh|mbh|ag|kg|ohg|e\.?\s*v\.?|gbr|se|ug)"
+
+
+def ns(collection: str) -> uuid.UUID:
+    return uuid.uuid5(NS_MHPKG, collection)
+
+
+def normalise(label: str) -> str:
+    """The umlaut rule, applied in order. Versioned: changing a step re-mints every Tier-3 IRI."""
+    s = unicodedata.normalize("NFC", label)  # 1 canonical composition
+    s = s.casefold()  # 2 case-insensitive (ß → ss)
+    s = re.sub(r"[^\w\s]", " ", s, flags=re.U)  # 3 punctuation → space
+    s = re.sub(r"\s+", " ", s).strip()  # 4 collapse + trim
+    s = re.sub(rf"\s+{LEGAL}$", "", s)  # 5 strip trailing legal form
+    return s.strip()
+
+
+def mint(collection: str, name: str) -> str:
+    """Tier 3: UUIDv5 over the identifying name. Never v4 — v4 is random."""
+    return f"{BASE}{collection}/{uuid.uuid5(ns(collection), name)}"
+
+
+# --- The slice: Kassel's 2024 heat plan, one target-scenario indicator ------------------
+
+AGS = "06611000"  # Kassel. 06 Hessen · 6 RB Kassel · 11 Stadt Kassel · 000 kreisfrei.
+PUBLISHED = "2024-03-15"
+
+MUNICIPALITY = f"{BASE}municipality/AGS_{AGS}"  # Tier 1: public register key
+HEATPLAN = f"{BASE}heatplan/AGS_{AGS}_{PUBLISHED}"  # Tier 2: key + discriminator
+TARGET_SCENARIO = f"{BASE}targetscenario/AGS_{AGS}_{PUBLISHED}"  # Tier 2
+
+# Tier 3. Value identity is its COORDINATES, never its magnitude — so correcting 241 to 2410
+# updates this node instead of orphaning it.
+INDICATOR = "https://openenergyplatform.org/ontology/oeo/OEO_00050016"  # final energy consumption
+ENERGY_CARRIER = "https://openenergyplatform.org/ontology/oeo/OEO_00000292"  # natural gas
+YEAR = "2030"
+AGGREGATION = "https://openenergyplatform.org/ontology/oeo/OEO_00140070"  # integral
+
+VALUE_TUPLE = "|".join([HEATPLAN, INDICATOR, ENERGY_CARRIER, YEAR, AGGREGATION])
+VALUE = mint("value", VALUE_TUPLE)
+
+# The contracted planner has no public register key, so Tier 3 over its normalised label.
+PLANNER_LABEL = "Kassel Wärme Ingenieurbüro"
+PLANNER = mint("organisation", normalise(PLANNER_LABEL))
+
+if __name__ == "__main__":
+    print(f"NS_MHPKG          = {NS_MHPKG}")
+    for coll in ("value", "organisation"):
+        print(f"NS[{coll:12}] = {ns(coll)}")
+    print()
+    print(f"municipality      {MUNICIPALITY}")
+    print(f"heat plan         {HEATPLAN}")
+    print(f"target scenario   {TARGET_SCENARIO}")
+    print(f"organisation      {PLANNER}")
+    print(f"   from label     {PLANNER_LABEL!r} -> {normalise(PLANNER_LABEL)!r}")
+    print()
+    print(f"value tuple       {VALUE_TUPLE}")
+    print(f"value             {VALUE}")
+    print()
+    print(f"data graph        {GRAPH}plan/AGS_{AGS}_{PUBLISHED}")
+    print(f"shapes graph      {GRAPH}shapes")
+    print()
+    # The trap the policy calls out, reproduced here so it stays visible: umlaut-stripped input
+    # does not error, it mints a DIFFERENT organisation. Concrete support for never
+    # machine-consuming Termboard output, which strips umlauts from IRI local names.
+    stripped = "Kassel Warme Ingenieurburo"
+    print(f"umlaut-stripped   {mint('organisation', normalise(stripped))}")
+    print("                  ^ a different organisation, silently. Not an error.")

--- a/mhpkg/schema/validate.py
+++ b/mhpkg/schema/validate.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate the example instances against the MHPKG shapes.
+
+WHY THIS EXISTS RATHER THAN A `pyshacl` COMMAND LINE. The shapes come in two files — the generated
+`generated/mhpkg_target_scenario.shacl.ttl` and the hand-written `mhpkg_iri_policy.shacl.ttl` — and
+`pyshacl` accepts repeated `-s` flags while SILENTLY USING ONLY THE LAST ONE. Two `-s` flags do not
+merge; the first shapes graph is discarded without a warning.
+
+That is not a theoretical hazard. It was hit while building this slice: the first run of the valid
+example reported `Conforms: True` with exit 0 against both files, and the generated shapes had not
+been consulted at all. Deleting a required label still reported conformance. The same invocation
+would have made a broken pipeline look healthy in CI.
+
+So the shapes are merged into one graph here, and the merge is not optional. Same class of trap as
+`uv sync --frozen` in MH-04 and `gen-shacl`'s exit-0-on-error: a check that reports success by
+doing nothing.
+
+The negative control is asserted, not merely run. `kassel_invalid.ttl` must fail, and it must fail
+for each of the reasons it is annotated with — a negative control that stopped catching four of its
+six cases would otherwise still be "failing" and still look fine.
+
+Usage:
+    python mhpkg/schema/validate.py
+Exit codes:
+    0  the valid example conforms AND every expected violation was found
+    1  otherwise
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from pyshacl import validate
+from rdflib import Graph
+
+HERE = Path(__file__).parent
+SHAPE_FILES = [
+    HERE / "generated" / "mhpkg_target_scenario.shacl.ttl",
+    HERE / "mhpkg_iri_policy.shacl.ttl",
+]
+VALID = HERE / "examples" / "kassel_valid.ttl"
+INVALID = HERE / "examples" / "kassel_invalid.ttl"
+
+# Each expected violation, as (label, constraint component, focus-node fragment, discriminator).
+#
+# The discriminator is load-bearing, not decoration. Cases 6b and 6c are both `In` violations on
+# one focus node, and 6a and 6d are both `MinInclusive` on that same node — so an expectation
+# written as (component, focus) alone would be satisfied by a SINGLE violation and would print
+# four ticks for two catches. Pinning a third field makes each line an independent assertion.
+#
+# It is a `Result Path:` line for property-level constraints, and a `Source Shape:` line for
+# node-level `sh:pattern`, which reports no path at all.
+EXPECTED = [
+    ("1  Tier-1 AGS missing its leading zero",
+     "Pattern", "municipality/AGS_6611000", "Source Shape: mhpkg_shapes:MunicipalityAreaIri"),
+    ("2  Tier-3 UUIDv4 where the policy requires v5",
+     "Pattern", "9f1e2d3c-4b5a-4c7d", "Source Shape: mhpkg_shapes:OrganisationIri"),
+    ("3a non-ASCII instance IRI",
+     "Pattern", "Kassel-W", "Source Shape: mhpkg_shapes:NoNonAsciiInstanceIri"),
+    ("3b …which is also not a UUID, so it fails the Tier-3 shape too",
+     "Pattern", "Kassel-W", "Source Shape: mhpkg_shapes:OrganisationIri"),
+    ("4a missing publication date",
+     "MinCount", "heatplan/AGS_06611000_2024-03-15", "Result Path: oeo:OEO_00390096"),
+    ("4b German label as @de instead of a plain literal",
+     "Datatype", "heatplan/AGS_06611000_2024-03-15", "Result Path: rdfs:label"),
+    ("5  Tier-2 IRI missing its date discriminator",
+     "Pattern", "targetscenario/AGS_06611000>", "Source Shape: mhpkg_shapes:TargetScenarioIri"),
+    ("6a negative energy consumption",
+     "MinInclusive", "a878a3a1-b856-5aaf", "Result Path: oeo:OEO_00140178"),
+    ("6b energy carrier outside the controlled vocabulary",
+     "In", "a878a3a1-b856-5aaf", "Result Path: oeo:OEO_00000523"),
+    ("6c sector slot holding an energy carrier",
+     "In", "a878a3a1-b856-5aaf", "Result Path: oeo:OEO_00000505"),
+    ("6d target year before the WPG existed",
+     "MinInclusive", "a878a3a1-b856-5aaf", "Result Path: oeo:OEO_00020440"),
+    ("7  undeclared property on a closed shape",
+     "Closed", "b1c2d3e4-f5a6", "Result Path: rdfs:seeAlso"),
+]
+
+# Consequences of the cases above rather than cases in their own right, listed so the report
+# accounts for every violation instead of quietly leaving two unexplained. The broken plan node in
+# case 4 points at a target scenario and an organisation that the invalid file does not define, so
+# `sh:class` cannot confirm their type. Real failures, just not designed ones.
+EXPECTED_CASCADES = [
+    ("dangling target scenario reference from case 4",
+     "Class", "heatplan/AGS_06611000_2024-03-15", "Result Path: obo:BFO_0000051"),
+    ("dangling organisation reference from case 4",
+     "Class", "heatplan/AGS_06611000_2024-03-15", "Result Path: oeo:OEO_00000510"),
+]
+
+
+def shapes_graph() -> Graph:
+    """Merge every shapes file into ONE graph. See the module docstring for why this matters."""
+    g = Graph()
+    for f in SHAPE_FILES:
+        g.parse(f, format="turtle")
+    return g
+
+
+def run(data: Path, shapes: Graph) -> tuple[bool, str]:
+    conforms, _, text = validate(
+        Graph().parse(data, format="turtle"),
+        shacl_graph=shapes,
+        advanced=True,
+    )
+    return conforms, text
+
+
+def main() -> int:
+    shapes = shapes_graph()
+    print(f"shapes: {len(shapes)} triples from {len(SHAPE_FILES)} files (merged, not stacked)")
+    ok = True
+
+    # --- The positive case ---
+    conforms, text = run(VALID, shapes)
+    print(f"\n{VALID.name}: {'CONFORMS' if conforms else 'FAILED'}")
+    if not conforms:
+        ok = False
+        print(text)
+
+    # --- The negative control ---
+    conforms, text = run(INVALID, shapes)
+    print(f"\n{INVALID.name}: {'conforms — WRONG, this must fail' if conforms else 'non-conforming, as intended'}")
+    if conforms:
+        return 1
+
+    blocks = text.split("Constraint Violation")[1:]
+
+    def caught(component: str, focus: str, discriminator: str) -> bool:
+        return any(
+            component in b and focus in b and discriminator in b
+            for b in blocks
+        )
+
+    print("\nexpected violations:")
+    for label, component, focus, discriminator in EXPECTED:
+        hit = caught(component, focus, discriminator)
+        print(f"  {'✅' if hit else '❌ NOT CAUGHT'}  {label}")
+        ok = ok and hit
+
+    print("\nexpected cascades (consequences, not designed cases):")
+    for label, component, focus, discriminator in EXPECTED_CASCADES:
+        hit = caught(component, focus, discriminator)
+        print(f"  {'✅' if hit else '❌ NOT CAUGHT'}  {label}")
+        ok = ok and hit
+
+    total = len(EXPECTED) + len(EXPECTED_CASCADES)
+    print(f"\n{len(blocks)} violations reported, {total} accounted for")
+    if len(blocks) != total:
+        print("  ⚠️ unexplained violations — the report above is incomplete")
+        ok = False
+
+    print("\nOK" if ok else "\nFAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary of the discussion

Covers a municipal heat plan, its target scenario and one final energy consumption value: deep enough to test the LinkML-authors-SHACL decision against real MHPO and OEO terms, small enough to finish.

The decision holds. gen-shacl puts class_uri straight into sh:targetClass, so the generated shapes constrain MHPO and OEO IRIs directly rather than a LinkML-shaped shadow of them. MHPO's role reification did not bite here, because OEO's quantity value already reifies the same way LinkML would — but that is a deferral, not a clearance: the areas-and-roles subtree is three quarters of MHPO and this slice does not enter it.

Enums are the pattern to reuse. OEO models units, carriers and sectors as classes while a statistic is about the carrier type, so pointing at a class IRI is unavoidable punning. An enum whose every meaning: is an OEO IRI generates sh:in, a real value-set constraint instead of sh:nodeKind sh:IRI. oekg/shapes/oekg_shapes.ttl already does this by hand for ~120 IRIs.

Four things that will shape later tickets:

* The IRI policy cannot be generated. SHACL constrains a node's own IRI with sh:pattern at node level and LinkML cannot emit that; a type-level pattern is dropped (silently with uri: set, otherwise logged as ERROR and still exit 0), and on an identifier slot it lands on an invented property that no triple uses, so it can never fire. Hence the hand-written companion file — the first artifact here that is not generated.
* Enum membership cannot be checked by anything in this repository. OEO's energy carrier has four asserted subclasses, all abstract; natural gas qualifies only by inference. Confirming membership needs a reasoner and the toolchain deliberately has none.
* MH-02 §6 and MHPO collide over the municipality. The policy reuses municipality/AGS_06611000 for the commissioning body, but the only class for it is municipality area — a spatial region cannot commission a plan, and the two IRI shapes cannot both be satisfied. Needs a human.
* pyshacl accepts repeated -s and silently uses only the last one. The first validation run reported Conforms: True against both shape files while consulting neither, and still passed with a required label deleted. validate.py merges the shapes into one graph for that reason.

Also recorded: closed shapes reject provenance triples; German labels must be plain literals because @de is rdf:langString and fails sh:datatype xsd:string; and Turtle cannot abbreviate these IRIs at all, since a prefixed name may not contain an unescaped slash.

Five term requests are left as commented blocks at the position they would occupy, so the holes are visible in the artifact. No term is minted here and gen-owl is never run.

Verified with linkml 1.11.1, pyshacl 0.40.1, rdflib 7.6.0 against MHPO pin 34776b6 and OEO 2.13.0. validate.py asserts all 14 negative-control violations are caught and exits 1 when the IRI shapes are removed.

## Type of change (CHANGELOG.md)

### Added
- `mhpkg/schema/`: first cut of the MHPKG data shape — a LinkML schema for one slice, the SHACL
  generated from it, a hand-written companion enforcing the IRI policy, and a passing plus a
  deliberately failing example [(#54)](https://github.com/OpenEnergyPlatform/oekg/pull/54)

### Updated
- Nothing. This PR only adds; `pyproject.toml` and `uv.lock` are deliberately untouched, since
  MH-04's `schema` and `graph` dependency groups already carried everything needed.

### Removed
- Nothing.

## Workflow checklist

### Automation
Closes #55 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
